### PR TITLE
Avoid blocking in random number generation of encryption salt

### DIFF
--- a/src/main/java/nl/martijndwars/webpush/PushService.java
+++ b/src/main/java/nl/martijndwars/webpush/PushService.java
@@ -23,6 +23,9 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
 
 public class PushService {
+
+    private static final SecureRandom SECURE_RANDOM = new SecureRandom();
+
     /**
      * The Google Cloud Messaging API key (for pre-VAPID in Chrome)
      */
@@ -83,7 +86,8 @@ public class PushService {
         Map<String, String> labels = new HashMap<>();
         labels.put("server-key-id", "P-256");
 
-        byte[] salt = SecureRandom.getSeed(16);
+        byte[] salt = new byte[16];
+        SECURE_RANDOM.nextBytes( salt );
 
         HttpEce httpEce = new HttpEce(keys, labels);
         byte[] ciphertext = httpEce.encrypt(buffer, salt, null, "server-key-id", userPublicKey, userAuth, padSize);


### PR DESCRIPTION
I made the SecureRandom instance as a static class variable. It's thread safe and the recommended way to use it:
https://stackoverflow.com/questions/27641981/repetitive-usage-of-javas-securerandom