### PR TITLE
Added jose4j logging library logback

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -150,6 +150,9 @@ dependencies {
     // For creating and signing JWT
     compile group: 'org.bitbucket.b_c', name: 'jose4j', version: '0.5.2'
 
+    // For jose4j logging
+    compile group: 'ch.qos.logback', name: 'logback-classic', version: '1.0.13'
+
     // For making HTTP requests
     testCompile group: 'org.apache.httpcomponents', name: 'fluent-hc', version: '4.5.2'
 


### PR DESCRIPTION
When I attempted to build via `./gradlew shadowJar` I was unable to execute a push because of a missing logging dependency for jose4j. For more information on the error I was running into look [here](https://bitbucket.org/b_c/jose4j/issues/82/jose4j-v053-could-not-initialize-class). I added the dependency to the build and my errors resolved.