### PR TITLE
Separate sending from making a post request

### DIFF
--- a/src/main/java/nl/martijndwars/webpush/PushService.java
+++ b/src/main/java/nl/martijndwars/webpush/PushService.java
@@ -128,6 +128,24 @@ public class PushService {
      * @throws JoseException
      */
     public Future<HttpResponse> sendAsync(Notification notification) throws GeneralSecurityException, IOException, JoseException {
+        HttpPost httpPost = preparePost(notification);
+
+        final CloseableHttpAsyncClient closeableHttpAsyncClient = HttpAsyncClients.createSystem();
+        closeableHttpAsyncClient.start();
+
+        return closeableHttpAsyncClient.execute(httpPost, new ClosableCallback(closeableHttpAsyncClient));
+    }
+
+    /**
+     * Prepare a HttpPost for Apache async http client
+     *
+     * @param notification
+     * @return
+     * @throws GeneralSecurityException
+     * @throws IOException
+     * @throws JoseException
+     */
+    public HttpPost preparePost(Notification notification) throws GeneralSecurityException, IOException, JoseException {
         assert (verifyKeyPair());
 
         BaseEncoding base64url = BaseEncoding.base64Url();
@@ -191,11 +209,7 @@ public class PushService {
         for (Map.Entry<String, String> entry : headers.entrySet()) {
             httpPost.addHeader(new BasicHeader(entry.getKey(), entry.getValue()));
         }
-
-        final CloseableHttpAsyncClient closeableHttpAsyncClient = HttpAsyncClients.createSystem();
-        closeableHttpAsyncClient.start();
-
-        return closeableHttpAsyncClient.execute(httpPost, new ClosableCallback(closeableHttpAsyncClient));
+        return httpPost;
     }
 
     private boolean verifyKeyPair() {


### PR DESCRIPTION
Extract HTTP post request creation into separate function to make sending more flexible

Currently there is no way to customize how `web-push-java` will send post request to endpoint. This change allows to use custom send strategies like async client with pooled connection manager