### PR TITLE
Removed guava compile dependency

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -141,8 +141,8 @@ dependencies {
     // For making async HTTP requests
     compile group: 'org.apache.httpcomponents', name: 'httpasyncclient', version: '4.1.3'
 
-    // Not sure what for..
-    compile group: 'com.google.guava', name: 'guava', version: '19.0'
+    // For Base64 encoding
+    compile group: 'commons-codec', name: 'commons-codec', version: '1.11'
 
     // For cryptographic operations
     compile group: 'org.bouncycastle', name: 'bcprov-jdk15on', version: '1.54'
@@ -164,4 +164,7 @@ dependencies {
 
     // For reading the demo vapid keypair from a pem file
     testCompile group: 'org.bouncycastle', name: 'bcpkix-jdk15on', version: '1.55'
+
+    // For verifying Base64Encoder results in unit tests
+    testCompile group: 'com.google.guava', name: 'guava', version: '19.0'
 }

--- a/build.gradle
+++ b/build.gradle
@@ -141,9 +141,6 @@ dependencies {
     // For making async HTTP requests
     compile group: 'org.apache.httpcomponents', name: 'httpasyncclient', version: '4.1.3'
 
-    // For Base64 encoding
-    compile group: 'commons-codec', name: 'commons-codec', version: '1.11'
-
     // For cryptographic operations
     compile group: 'org.bouncycastle', name: 'bcprov-jdk15on', version: '1.54'
 

--- a/src/main/java/nl/martijndwars/webpush/Base64Encoder.java
+++ b/src/main/java/nl/martijndwars/webpush/Base64Encoder.java
@@ -1,0 +1,51 @@
+package nl.martijndwars.webpush;
+
+
+import org.apache.commons.codec.binary.Base64;
+
+/**
+ * Java 7 compatible Base64 encode/decode functions. Based on Apache Commons Codec.
+ *
+ * <p>
+ * Note: Once upgrading to Java 8+, replace by native Base64 encoder.
+ * </p>
+ */
+public class Base64Encoder {
+
+    public static byte[] decode(String base64Encoded) {
+        return Base64.decodeBase64(base64Encoded);
+    }
+
+    public static String encodeWithoutPadding(byte[] bytes) {
+        return unpad(Base64.encodeBase64String(bytes));
+    }
+
+    public static String encodeUrl(byte[] bytes) {
+        return pad(Base64.encodeBase64URLSafeString(bytes));
+    }
+
+    public static String encodeUrlWithoutPadding(byte[] bytes) {
+        return Base64.encodeBase64URLSafeString(bytes);
+    }
+
+    private static String pad(String base64Encoded) {
+        int m = base64Encoded.length() % 4;
+        if (m == 2) {
+            return base64Encoded + "==";
+        } else if (m == 3) {
+            return base64Encoded + "=";
+        } else {
+            return base64Encoded;
+        }
+    }
+
+    private static String unpad(String base64Encoded) {
+        if (base64Encoded.endsWith("==")) {
+            return base64Encoded.substring(0, base64Encoded.length() - 2);
+        } else if (base64Encoded.endsWith("=")) {
+            return base64Encoded.substring(0, base64Encoded.length() - 1);
+        } else {
+            return base64Encoded;
+        }
+    }
+}

--- a/src/main/java/nl/martijndwars/webpush/Notification.java
+++ b/src/main/java/nl/martijndwars/webpush/Notification.java
@@ -48,11 +48,11 @@ public class Notification {
     }
 
     public Notification(String endpoint, String userPublicKey, String userAuth, byte[] payload) throws NoSuchAlgorithmException, NoSuchProviderException, InvalidKeySpecException {
-        this(endpoint, Utils.loadPublicKey(userPublicKey), Utils.base64Decode(userAuth), payload);
+        this(endpoint, Utils.loadPublicKey(userPublicKey), Base64Encoder.decode(userAuth), payload);
     }
 
     public Notification(String endpoint, String userPublicKey, String userAuth, String payload) throws NoSuchAlgorithmException, NoSuchProviderException, InvalidKeySpecException {
-        this(endpoint, Utils.loadPublicKey(userPublicKey), Utils.base64Decode(userAuth), payload.getBytes(UTF_8));
+        this(endpoint, Utils.loadPublicKey(userPublicKey), Base64Encoder.decode(userAuth), payload.getBytes(UTF_8));
     }
 
     public Notification(Subscription subscription, String payload) throws NoSuchAlgorithmException, NoSuchProviderException, InvalidKeySpecException {

--- a/src/main/java/nl/martijndwars/webpush/PushService.java
+++ b/src/main/java/nl/martijndwars/webpush/PushService.java
@@ -1,6 +1,5 @@
 package nl.martijndwars.webpush;
 
-import com.google.common.io.BaseEncoding;
 import org.apache.http.HttpResponse;
 import org.apache.http.client.methods.HttpPost;
 import org.apache.http.entity.ByteArrayEntity;
@@ -148,7 +147,6 @@ public class PushService {
     public HttpPost preparePost(Notification notification) throws GeneralSecurityException, IOException, JoseException {
         assert (verifyKeyPair());
 
-        BaseEncoding base64url = BaseEncoding.base64Url();
 
         Encrypted encrypted = encrypt(
                 notification.getPayload(),
@@ -168,8 +166,8 @@ public class PushService {
         if (notification.hasPayload()) {
             headers.put("Content-Type", "application/octet-stream");
             headers.put("Content-Encoding", "aesgcm");
-            headers.put("Encryption", "salt=" + base64url.omitPadding().encode(salt));
-            headers.put("Crypto-Key", "dh=" + base64url.encode(dh));
+            headers.put("Encryption", "salt=" + Base64Encoder.encodeUrlWithoutPadding(salt));
+            headers.put("Crypto-Key", "dh=" + Base64Encoder.encodeUrl(dh));
 
             httpPost.setEntity(new ByteArrayEntity(encrypted.getCiphertext()));
         }
@@ -200,9 +198,9 @@ public class PushService {
             byte[] pk = Utils.savePublicKey((ECPublicKey) publicKey);
 
             if (headers.containsKey("Crypto-Key")) {
-                headers.put("Crypto-Key", headers.get("Crypto-Key") + ";p256ecdsa=" + base64url.omitPadding().encode(pk));
+                headers.put("Crypto-Key", headers.get("Crypto-Key") + ";p256ecdsa=" + Base64Encoder.encodeUrlWithoutPadding(pk));
             } else {
-                headers.put("Crypto-Key", "p256ecdsa=" + base64url.encode(pk));
+                headers.put("Crypto-Key", "p256ecdsa=" + Base64Encoder.encodeUrl(pk));
             }
         }
 

--- a/src/main/java/nl/martijndwars/webpush/Utils.java
+++ b/src/main/java/nl/martijndwars/webpush/Utils.java
@@ -1,10 +1,8 @@
 package nl.martijndwars.webpush;
 
-import com.google.common.io.BaseEncoding;
 import org.bouncycastle.jce.ECNamedCurveTable;
 import org.bouncycastle.jce.interfaces.ECPrivateKey;
 import org.bouncycastle.jce.interfaces.ECPublicKey;
-import org.bouncycastle.jce.provider.BouncyCastleProvider;
 import org.bouncycastle.jce.spec.ECParameterSpec;
 import org.bouncycastle.jce.spec.ECPrivateKeySpec;
 import org.bouncycastle.jce.spec.ECPublicKeySpec;
@@ -39,28 +37,13 @@ public class Utils {
     }
 
     /**
-     * Base64-decode a string. Works for both url-safe and non-url-safe
-     * encodings.
-     *
-     * @param base64Encoded
-     * @return
-     */
-    public static byte[] base64Decode(String base64Encoded) {
-        if (base64Encoded.contains("+") || base64Encoded.contains("/")) {
-            return BaseEncoding.base64().decode(base64Encoded);
-        } else {
-            return BaseEncoding.base64Url().decode(base64Encoded);
-        }
-    }
-
-    /**
      * Load the public key from a URL-safe base64 encoded string. Takes into
      * account the different encodings, including point compression.
      *
      * @param encodedPublicKey
      */
     public static PublicKey loadPublicKey(String encodedPublicKey) throws NoSuchProviderException, NoSuchAlgorithmException, InvalidKeySpecException {
-        byte[] decodedPublicKey = base64Decode(encodedPublicKey);
+        byte[] decodedPublicKey = Base64Encoder.decode(encodedPublicKey);
         KeyFactory keyFactory = KeyFactory.getInstance(ALGORITHM, PROVIDER_NAME);
         ECParameterSpec parameterSpec = ECNamedCurveTable.getParameterSpec(CURVE);
         ECCurve curve = parameterSpec.getCurve();
@@ -80,7 +63,7 @@ public class Utils {
      * @throws InvalidKeySpecException
      */
     public static PrivateKey loadPrivateKey(String encodedPrivateKey) throws NoSuchProviderException, NoSuchAlgorithmException, InvalidKeySpecException {
-        byte[] decodedPrivateKey = base64Decode(encodedPrivateKey);
+        byte[] decodedPrivateKey = Base64Encoder.decode(encodedPrivateKey);
         BigInteger s = BigIntegers.fromUnsignedByteArray(decodedPrivateKey);
         ECParameterSpec parameterSpec = ECNamedCurveTable.getParameterSpec(CURVE);
         ECPrivateKeySpec privateKeySpec = new ECPrivateKeySpec(s, parameterSpec);

--- a/src/main/java/nl/martijndwars/webpush/cli/handlers/GenerateKeyHandler.java
+++ b/src/main/java/nl/martijndwars/webpush/cli/handlers/GenerateKeyHandler.java
@@ -1,6 +1,6 @@
 package nl.martijndwars.webpush.cli.handlers;
 
-import com.google.common.io.BaseEncoding;
+import nl.martijndwars.webpush.Base64Encoder;
 import nl.martijndwars.webpush.Utils;
 import nl.martijndwars.webpush.cli.commands.GenerateKeyCommand;
 import org.bouncycastle.jce.ECNamedCurveTable;
@@ -39,10 +39,10 @@ public class GenerateKeyHandler implements HandlerInterface {
         }
 
         System.out.println("PublicKey:");
-        System.out.println(BaseEncoding.base64Url().encode(publicKey));
+        System.out.println(Base64Encoder.encodeUrl(publicKey));
 
         System.out.println("PrivateKey:");
-        System.out.println(BaseEncoding.base64Url().encode(privateKey));
+        System.out.println(Base64Encoder.encodeUrl(privateKey));
     }
 
     /**

--- a/src/test/java/nl/martijndwars/webpush/Base64EncoderTest.java
+++ b/src/test/java/nl/martijndwars/webpush/Base64EncoderTest.java
@@ -1,0 +1,128 @@
+package nl.martijndwars.webpush;
+
+import org.junit.jupiter.api.Test;
+
+import static com.google.common.io.BaseEncoding.base64;
+import static com.google.common.io.BaseEncoding.base64Url;
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static nl.martijndwars.webpush.Base64Encoder.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class Base64EncoderTest {
+
+    @Test
+    void decodeTest() {
+        // first compare with previous guava implementation, make sure non-breaking changes
+        assertEquals(new String(base64().decode("")), new String(decode("")));
+        assertEquals(new String(base64().decode("dw")), new String(decode("dw")));
+        assertEquals(new String(base64().decode("dw==")), new String(decode("dw==")));
+        assertEquals(new String(base64().decode("d2U")), new String(decode("d2U")));
+        assertEquals(new String(base64().decode("d2Vi")), new String(decode("d2Vi")));
+        assertEquals(new String(base64().decode("d2ViLQ")), new String(decode("d2ViLQ")));
+        assertEquals(new String(base64().decode("d2ViLQ==")), new String(decode("d2ViLQ==")));
+        assertEquals(new String(base64().decode("d2ViLXA")), new String(decode("d2ViLXA")));
+        assertEquals(new String(base64().decode("d2ViLXA=")), new String(decode("d2ViLXA=")));
+        assertEquals(new String(base64().decode("d2ViLXB1")), new String(decode("d2ViLXB1")));
+        assertEquals(new String(base64().decode("d2ViLXB1cw")), new String(decode("d2ViLXB1cw")));
+        assertEquals(new String(base64().decode("d2ViLXB1cw==")), new String(decode("d2ViLXB1cw==")));
+        assertEquals(new String(base64().decode("d2ViLXB1c2g")), new String(decode("d2ViLXB1c2g")));
+        assertEquals(new String(base64().decode("d2ViLXB1c2g=")), new String(decode("d2ViLXB1c2g=")));
+        assertEquals(new String(base64().decode("d2ViLXB1c2g/")), new String(decode("d2ViLXB1c2g/")));
+        assertEquals(new String(base64Url().decode("d2ViLXB1c2g_")), new String(decode("d2ViLXB1c2g_")));
+
+        assertEquals("", new String(decode("")));
+        assertEquals("w", new String(decode("dw")));
+        assertEquals("w", new String(decode("dw==")));
+        assertEquals("we", new String(decode("d2U")));
+        assertEquals("web", new String(decode("d2Vi")));
+        assertEquals("web-", new String(decode("d2ViLQ")));
+        assertEquals("web-", new String(decode("d2ViLQ==")));
+        assertEquals("web-p", new String(decode("d2ViLXA")));
+        assertEquals("web-p", new String(decode("d2ViLXA=")));
+        assertEquals("web-pu", new String(decode("d2ViLXB1")));
+        assertEquals("web-pus", new String(decode("d2ViLXB1cw")));
+        assertEquals("web-pus", new String(decode("d2ViLXB1cw==")));
+        assertEquals("web-push", new String(decode("d2ViLXB1c2g")));
+        assertEquals("web-push", new String(decode("d2ViLXB1c2g=")));
+        assertEquals("web-push?", new String(decode("d2ViLXB1c2g/")));
+        assertEquals("web-push?", new String(decode("d2ViLXB1c2g_")));
+    }
+
+    @Test
+    void encodeWithoutPaddingTest() {
+        // first verify non breaking changes after removing guava as compile dependency
+        assertEquals(base64().omitPadding().encode("".getBytes()), encodeWithoutPadding("".getBytes(UTF_8)));
+        assertEquals(base64().omitPadding().encode("w".getBytes()), encodeWithoutPadding("w".getBytes(UTF_8)));
+        assertEquals(base64().omitPadding().encode("we".getBytes()), encodeWithoutPadding("we".getBytes(UTF_8)));
+        assertEquals(base64().omitPadding().encode("web".getBytes()), encodeWithoutPadding("web".getBytes(UTF_8)));
+        assertEquals(base64().omitPadding().encode("web-".getBytes()), encodeWithoutPadding("web-".getBytes(UTF_8)));
+        assertEquals(base64().omitPadding().encode("web-p".getBytes()), encodeWithoutPadding("web-p".getBytes(UTF_8)));
+        assertEquals(base64().omitPadding().encode("web-pu".getBytes()), encodeWithoutPadding("web-pu".getBytes(UTF_8)));
+        assertEquals(base64().omitPadding().encode("web-pus".getBytes()), encodeWithoutPadding("web-pus".getBytes(UTF_8)));
+        assertEquals(base64().omitPadding().encode("web-push".getBytes()), encodeWithoutPadding("web-push".getBytes(UTF_8)));
+        assertEquals(base64().omitPadding().encode("web-push?".getBytes()), encodeWithoutPadding("web-push?".getBytes(UTF_8)));
+
+        assertEquals("", encodeWithoutPadding("".getBytes(UTF_8)));
+        assertEquals("dw", encodeWithoutPadding("w".getBytes(UTF_8)));
+        assertEquals("d2U", encodeWithoutPadding("we".getBytes(UTF_8)));
+        assertEquals("d2Vi", encodeWithoutPadding("web".getBytes(UTF_8)));
+        assertEquals("d2ViLQ", encodeWithoutPadding("web-".getBytes(UTF_8)));
+        assertEquals("d2ViLXA", encodeWithoutPadding("web-p".getBytes(UTF_8)));
+        assertEquals("d2ViLXB1", encodeWithoutPadding("web-pu".getBytes(UTF_8)));
+        assertEquals("d2ViLXB1cw", encodeWithoutPadding("web-pus".getBytes(UTF_8)));
+        assertEquals("d2ViLXB1c2g", encodeWithoutPadding("web-push".getBytes(UTF_8)));
+        assertEquals("d2ViLXB1c2g/", encodeWithoutPadding("web-push?".getBytes(UTF_8)));
+    }
+
+    @Test
+    void encodeUrlTest() {
+        // first verify non breaking changes after removing guava as compile dependency
+        assertEquals(base64Url().encode("".getBytes()), encodeUrl("".getBytes(UTF_8)));
+        assertEquals(base64Url().encode("w".getBytes()), encodeUrl("w".getBytes(UTF_8)));
+        assertEquals(base64Url().encode("we".getBytes()), encodeUrl("we".getBytes(UTF_8)));
+        assertEquals(base64Url().encode("web".getBytes()), encodeUrl("web".getBytes(UTF_8)));
+        assertEquals(base64Url().encode("web-".getBytes()), encodeUrl("web-".getBytes(UTF_8)));
+        assertEquals(base64Url().encode("web-p".getBytes()), encodeUrl("web-p".getBytes(UTF_8)));
+        assertEquals(base64Url().encode("web-pu".getBytes()), encodeUrl("web-pu".getBytes(UTF_8)));
+        assertEquals(base64Url().encode("web-pus".getBytes()), encodeUrl("web-pus".getBytes(UTF_8)));
+        assertEquals(base64Url().encode("web-push".getBytes()), encodeUrl("web-push".getBytes(UTF_8)));
+        assertEquals(base64Url().encode("web-push?".getBytes()), encodeUrl("web-push?".getBytes(UTF_8)));
+
+        assertEquals("", encodeUrl("".getBytes(UTF_8)));
+        assertEquals("dw==", encodeUrl("w".getBytes(UTF_8)));
+        assertEquals("d2U=", encodeUrl("we".getBytes(UTF_8)));
+        assertEquals("d2Vi", encodeUrl("web".getBytes(UTF_8)));
+        assertEquals("d2ViLQ==", encodeUrl("web-".getBytes(UTF_8)));
+        assertEquals("d2ViLXA=", encodeUrl("web-p".getBytes(UTF_8)));
+        assertEquals("d2ViLXB1", encodeUrl("web-pu".getBytes(UTF_8)));
+        assertEquals("d2ViLXB1cw==", encodeUrl("web-pus".getBytes(UTF_8)));
+        assertEquals("d2ViLXB1c2g=", encodeUrl("web-push".getBytes(UTF_8)));
+        assertEquals("d2ViLXB1c2g_", encodeUrl("web-push?".getBytes(UTF_8)));
+    }
+
+    @Test
+    void encodeUrlWithoutPaddingTest() {
+        // first verify non breaking changes after removing guava as compile dependency
+        assertEquals(base64Url().omitPadding().encode("".getBytes()), encodeUrlWithoutPadding("".getBytes(UTF_8)));
+        assertEquals(base64Url().omitPadding().encode("w".getBytes()), encodeUrlWithoutPadding("w".getBytes(UTF_8)));
+        assertEquals(base64Url().omitPadding().encode("we".getBytes()), encodeUrlWithoutPadding("we".getBytes(UTF_8)));
+        assertEquals(base64Url().omitPadding().encode("web".getBytes()), encodeUrlWithoutPadding("web".getBytes(UTF_8)));
+        assertEquals(base64Url().omitPadding().encode("web-".getBytes()), encodeUrlWithoutPadding("web-".getBytes(UTF_8)));
+        assertEquals(base64Url().omitPadding().encode("web-p".getBytes()), encodeUrlWithoutPadding("web-p".getBytes(UTF_8)));
+        assertEquals(base64Url().omitPadding().encode("web-pu".getBytes()), encodeUrlWithoutPadding("web-pu".getBytes(UTF_8)));
+        assertEquals(base64Url().omitPadding().encode("web-pus".getBytes()), encodeUrlWithoutPadding("web-pus".getBytes(UTF_8)));
+        assertEquals(base64Url().omitPadding().encode("web-push".getBytes()), encodeUrlWithoutPadding("web-push".getBytes(UTF_8)));
+        assertEquals(base64Url().omitPadding().encode("web-push?".getBytes()), encodeUrlWithoutPadding("web-push?".getBytes(UTF_8)));
+
+        assertEquals("", encodeUrlWithoutPadding("".getBytes(UTF_8)));
+        assertEquals("dw", encodeUrlWithoutPadding("w".getBytes(UTF_8)));
+        assertEquals("d2U", encodeUrlWithoutPadding("we".getBytes(UTF_8)));
+        assertEquals("d2Vi", encodeUrlWithoutPadding("web".getBytes(UTF_8)));
+        assertEquals("d2ViLQ", encodeUrlWithoutPadding("web-".getBytes(UTF_8)));
+        assertEquals("d2ViLXA", encodeUrlWithoutPadding("web-p".getBytes(UTF_8)));
+        assertEquals("d2ViLXB1", encodeUrlWithoutPadding("web-pu".getBytes(UTF_8)));
+        assertEquals("d2ViLXB1cw", encodeUrlWithoutPadding("web-pus".getBytes(UTF_8)));
+        assertEquals("d2ViLXB1c2g", encodeUrlWithoutPadding("web-push".getBytes(UTF_8)));
+        assertEquals("d2ViLXB1c2g_", encodeUrlWithoutPadding("web-push?".getBytes(UTF_8)));
+    }
+}

--- a/src/test/java/nl/martijndwars/webpush/selenium/SeleniumTests.java
+++ b/src/test/java/nl/martijndwars/webpush/selenium/SeleniumTests.java
@@ -1,6 +1,6 @@
 package nl.martijndwars.webpush.selenium;
 
-import com.google.common.io.BaseEncoding;
+import nl.martijndwars.webpush.Base64Encoder;
 import nl.martijndwars.webpush.PushService;
 import org.bouncycastle.jce.provider.BouncyCastleProvider;
 import org.junit.jupiter.api.AfterAll;
@@ -64,10 +64,8 @@ public class SeleniumTests {
      * @return
      */
     protected Stream<Configuration> getConfigurations() {
-        BaseEncoding base64Encoding = BaseEncoding.base64();
-
-        String PUBLIC_KEY_NO_PADDING = base64Encoding.omitPadding().encode(
-                base64Encoding.decode(PUBLIC_KEY)
+        String PUBLIC_KEY_NO_PADDING = Base64Encoder.encodeWithoutPadding(
+                Base64Encoder.decode(PUBLIC_KEY)
         );
 
         return Stream.of(


### PR DESCRIPTION
- removed guava, now using apache commons codec for base64 encoding (~320kb)
- since webpush lib should stick to java 7, native base64 encoder of java 8 could not be used 

@MartijnDwars I kept guava as testCompile dependency for now. just to make sure that there are non breaking changes with this pr (see Base64EncoderTest). but this could be removed as well. what do you think?