### PR TITLE
Add aes128gcm support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ build/
 .gradle/
 *.iml
 target/
+out/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,5 @@
+# 4.0.0
+
+* Support [aes128gcm content encoding](https://tools.ietf.org/html/draft-ietf-httpbis-encryption-encoding-09#section-2)
+  * Use `PushService.send(Notification, Encoding)` or the analogous `sendAsync` with `Encoding.AES128GCM`.
+

--- a/README.md
+++ b/README.md
@@ -176,6 +176,7 @@ To give credit where credit is due, the PushService is mostly a Java port of mar
 
 - [Voluntary Application Server Identification for Web Push](https://tools.ietf.org/html/draft-ietf-webpush-vapid-01)
 - [Web Push Book](https://web-push-book.gauntface.com/)
+- [Simple Push Demo](https://gauntface.github.io/simple-push-demo/)
 - [Web Push: Data Encryption Test Page](https://jrconlin.github.io/WebPushDataTestPage/)
 - [Push Companion](https://web-push-codelab.appspot.com/)
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,41 @@
+# Release process
+
+1. Update version string in `build.gradle` (twice), `README.md` to the final version (i.e. non-SNAPSHOT).
+
+```
+./scripts/version.sh OLD_VERSION NEW_VERSION
+```
+
+2. Commit "Release x.y.z", tag this commit with the new version "x.y.z".
+
+```
+git commit -m "Release NEW_VERSION"
+git tag -a NEW_VERSION
+```
+
+3. [Deploy to OSSRH with Gradle](http://central.sonatype.org/pages/gradle.html):
+
+```
+./gradlew -Prelease uploadArchives
+```
+
+4. [Releasing the Deployment](http://central.sonatype.org/pages/releasing-the-deployment.html):
+
+```
+./gradlew -Prelease closeAndReleaseRepository
+```
+
+5. Increment to next version with -SNAPSHOT suffix
+
+```
+./scripts/version.sh OLD_VERSION NEW_VERSION-SNAPSHOT
+...
+```
+
+6. Create a commit for the new version "Set version to a.b.c-SNAPSHOT"
+
+```
+git add README.md build.gradle
+git commit -m "Set version to NEW_VERSION-SNAPSHOT"
+```
+

--- a/build.gradle
+++ b/build.gradle
@@ -1,130 +1,22 @@
-buildscript {
-    repositories {
-        mavenCentral()
-    }
-    dependencies {
-        classpath 'org.junit.platform:junit-platform-gradle-plugin:1.0.0-M4'
-        classpath 'io.codearte.gradle.nexus:gradle-nexus-staging-plugin:0.8.0'
-    }
+plugins {
+    id 'application'
+    id 'com.github.johnrengelman.shadow' version '4.0.2'
+
+    // Used by release.gradle
+    id 'maven'
+    id 'signing'
+    id 'io.codearte.nexus-staging' version '0.12.0'
 }
 
-plugins {
-    id 'com.github.johnrengelman.shadow' version '2.0.0'
+if (hasProperty('release')) {
+    apply from: 'release.gradle'
 }
+
+apply plugin: 'application'
+apply plugin: 'com.github.johnrengelman.shadow'
 
 group 'nl.martijndwars'
 version '3.1.1'
-
-apply plugin: 'java'
-apply plugin: 'maven'
-apply plugin: 'signing'
-apply plugin: 'org.junit.platform.gradle.plugin'
-apply plugin: 'io.codearte.nexus-staging'
-
-task wrapper(type: Wrapper) {
-    gradleVersion = '3.0'
-}
-
-compileJava {
-    sourceCompatibility = 1.7
-    targetCompatibility = 1.7
-}
-
-compileTestJava {
-    sourceCompatibility = 1.8
-}
-
-jar {
-    baseName = 'web-push'
-    version = '3.1.1'
-}
-
-shadowJar {
-    // BouncyCastle JAR is signed; it cannot be extracted and merged into the fat JAR.
-    dependencies {
-        exclude(
-            dependency(group: 'org.bouncycastle', name: 'bcprov-jdk15on', version: '1.54')
-        )
-    }
-    manifest {
-        attributes 'Main-Class': 'nl.martijndwars.webpush.cli.Cli',
-                   'Class-Path': '../../lib/bcprov-jdk15on-154.jar'
-    }
-}
-
-junitPlatform {
-    selectors {
-        aClass 'nl.martijndwars.webpush.selenium.SeleniumTests'
-    }
-}
-
-task javadocJar(type: Jar) {
-    classifier = 'javadoc'
-    from javadoc
-}
-
-task sourcesJar(type: Jar) {
-    classifier = 'sources'
-    from sourceSets.main.allSource
-}
-
-artifacts {
-    archives javadocJar, sourcesJar
-}
-
-signing {
-    sign configurations.archives
-}
-
-uploadArchives {
-  repositories {
-    mavenDeployer {
-      beforeDeployment { MavenDeployment deployment -> signing.signPom(deployment) }
-
-      repository(url: "https://oss.sonatype.org/service/local/staging/deploy/maven2/") {
-        authentication(
-          userName: project.hasProperty('ossrhPassword') ? ossrhUsername : '',
-          password: project.hasProperty('ossrhPassword') ? ossrhPassword : ''
-        )
-      }
-
-      snapshotRepository(url: "https://oss.sonatype.org/content/repositories/snapshots/") {
-        authentication(
-          userName: project.hasProperty('ossrhPassword') ? ossrhUsername : '',
-          password: project.hasProperty('ossrhPassword') ? ossrhPassword : ''
-        )
-      }
-
-      pom.project {
-        name 'web-push'
-        packaging 'jar'
-        description 'A Web Push library for Java.'
-        url 'https://github.com/web-push-libs/webpush-java'
-
-        scm {
-          connection 'scm:git:git@github.com:web-push-libs/webpush-java.git'
-          developerConnection 'scm:git:git@github.com:web-push-libs/webpush-java.git'
-          url 'git@github.com:web-push-libs/webpush-java.git'
-        }
-
-        licenses {
-          license {
-            name 'MIT License'
-            url 'https://opensource.org/licenses/MIT'
-          }
-        }
-
-        developers {
-          developer {
-            id 'martijndwars'
-            name 'Martijn Dwars'
-            email 'ikben@martijndwars.nl'
-          }
-        }
-      }
-    }
-  }
-}
 
 repositories {
     mavenLocal()
@@ -151,10 +43,10 @@ dependencies {
     testCompile group: 'org.apache.httpcomponents', name: 'fluent-hc', version: '4.5.2'
 
     // For testing, obviously
-    testCompile group: 'org.junit.jupiter', name: 'junit-jupiter-api', version: '5.0.0-M4'
+    testCompile group: 'org.junit.jupiter', name: 'junit-jupiter-api', version: '5.3.1'
 
     // For running JUnit tests
-    testRuntime group: 'org.junit.jupiter', name: 'junit-jupiter-engine', version: '5.0.0-M4'
+    testRuntime group: 'org.junit.jupiter', name: 'junit-jupiter-engine', version: '5.3.1'
 
     // For turning InputStream to String
     testCompile group: 'commons-io', name: 'commons-io', version: '2.5'
@@ -164,4 +56,52 @@ dependencies {
 
     // For verifying Base64Encoder results in unit tests
     testCompile group: 'com.google.guava', name: 'guava', version: '19.0'
+}
+
+wrapper {
+    gradleVersion = '4.10.2'
+}
+
+compileJava {
+    sourceCompatibility = 1.7
+    targetCompatibility = 1.7
+}
+
+compileTestJava {
+    sourceCompatibility = 1.8
+}
+
+mainClassName = 'nl.martijndwars.webpush.cli.Cli'
+
+shadowJar {
+    // BouncyCastle JAR is signed; it cannot be extracted and merged into the fat JAR.
+    dependencies {
+        exclude(
+            dependency(group: 'org.bouncycastle', name: 'bcprov-jdk15on', version: '1.54')
+        )
+    }
+    manifest {
+        attributes 'Class-Path': '../../lib/bcprov-jdk15on-154.jar'
+    }
+}
+
+test {
+    useJUnitPlatform()
+
+    // TODO: Make the other test proper unit tests and remove this filter.
+    include '**/SeleniumTests.class'
+}
+
+task javadocJar(type: Jar) {
+    classifier = 'javadoc'
+    from javadoc
+}
+
+task sourcesJar(type: Jar) {
+    classifier = 'sources'
+    from sourceSets.main.allSource
+}
+
+artifacts {
+    archives javadocJar, sourcesJar
 }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Mon May 29 11:45:53 PDT 2017
+#Sun Sep 30 11:51:22 CEST 2018
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-3.0-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.10.2-bin.zip

--- a/release.gradle
+++ b/release.gradle
@@ -1,0 +1,55 @@
+signing {
+    sign configurations.archives
+}
+
+uploadArchives {
+    repositories {
+        mavenDeployer {
+            beforeDeployment { MavenDeployment deployment ->
+                signing.signPom(deployment)
+            }
+
+            repository(url: "https://oss.sonatype.org/service/local/staging/deploy/maven2/") {
+                authentication(
+                    userName: ossrhUsername,
+                    password: ossrhPassword
+                )
+            }
+
+            snapshotRepository(url: "https://oss.sonatype.org/content/repositories/snapshots/") {
+                authentication(
+                    userName: ossrhUsername,
+                    password: ossrhPassword
+                )
+            }
+
+            pom.project {
+                name 'web-push'
+                packaging 'jar'
+                description 'A Web Push library for Java.'
+                url 'https://github.com/web-push-libs/webpush-java'
+
+                scm {
+                    connection 'scm:git:git@github.com:web-push-libs/webpush-java.git'
+                    developerConnection 'scm:git:git@github.com:web-push-libs/webpush-java.git'
+                    url 'git@github.com:web-push-libs/webpush-java.git'
+                }
+
+                licenses {
+                    license {
+                        name 'MIT License'
+                        url 'https://opensource.org/licenses/MIT'
+                    }
+                }
+
+                developers {
+                    developer {
+                        id 'martijndwars'
+                        name 'Martijn Dwars'
+                        email 'ikben@martijndwars.nl'
+                    }
+                }
+            }
+        }
+    }
+}

--- a/scripts/version.sh
+++ b/scripts/version.sh
@@ -1,0 +1,20 @@
+#/usr/bin/env sh
+set -eu
+
+if [ "$#" -ne 2 ]; then
+  echo "Usage: version.sh OLD_VERSION NEW_VERSION" && exit 1
+fi
+
+OLD_VERSION=$1
+NEW_VERSION=$2
+
+files=(
+  "build.gradle"
+  "README.md"
+)
+
+for file in ${files[@]}; do
+  sed -i '' "s/$OLD_VERSION/$NEW_VERSION/g" $file
+done
+
+

--- a/src/main/java/nl/martijndwars/webpush/Encoding.java
+++ b/src/main/java/nl/martijndwars/webpush/Encoding.java
@@ -1,0 +1,5 @@
+package nl.martijndwars.webpush;
+
+public enum Encoding {
+    AESGCM, AES128GCM
+}

--- a/src/main/java/nl/martijndwars/webpush/HttpEce.java
+++ b/src/main/java/nl/martijndwars/webpush/HttpEce.java
@@ -3,29 +3,181 @@ package nl.martijndwars.webpush;
 import org.bouncycastle.crypto.digests.SHA256Digest;
 import org.bouncycastle.crypto.generators.HKDFBytesGenerator;
 import org.bouncycastle.crypto.params.HKDFParameters;
+import org.bouncycastle.jce.interfaces.ECPrivateKey;
 import org.bouncycastle.jce.interfaces.ECPublicKey;
 
 import javax.crypto.*;
 import javax.crypto.spec.GCMParameterSpec;
 import javax.crypto.spec.SecretKeySpec;
-import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.security.*;
+import java.util.Arrays;
+import java.util.HashMap;
 import java.util.Map;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
+import static javax.crypto.Cipher.DECRYPT_MODE;
+import static javax.crypto.Cipher.ENCRYPT_MODE;
+import static nl.martijndwars.webpush.Utils.*;
 
 /**
- * An implementation of HTTP ECE (Encrypted Content Encoding) as described in
- * https://tools.ietf.org/html/draft-ietf-httpbis-encryption-encoding-01
+ * An implementation of Encrypted Content-Encoding for HTTP.
+ *
+ * The first implementation follows the specification in [1]. The specification later moved from
+ * "aesgcm" to "aes128gcm" as content encoding [2]. To remain backwards compatible this library
+ * supports both.
+ *
+ * [1] https://tools.ietf.org/html/draft-ietf-httpbis-encryption-encoding-01
+ * [2] https://tools.ietf.org/html/draft-ietf-httpbis-encryption-encoding-09
+ *
+ * TODO: Support multiple records (not needed for Web Push)
  */
 public class HttpEce {
+    public static final int KEY_LENGTH = 16;
+    public static final int SHA_256_LENGTH = 32;
+    public static final int TAG_SIZE = 16;
+    public static final int TWO_BYTE_MAX = 65_536;
+    public static final String WEB_PUSH_INFO = "WebPush: info\0";
+
     private Map<String, KeyPair> keys;
     private Map<String, String> labels;
+
+    public HttpEce() {
+        this(new HashMap<String, KeyPair>(), new HashMap<String, String>());
+    }
 
     public HttpEce(Map<String, KeyPair> keys, Map<String, String> labels) {
         this.keys = keys;
         this.labels = labels;
+    }
+
+    /**
+     * Encrypt the given plaintext.
+     *
+     * @param plaintext    Payload to encrypt.
+     * @param salt       A random 16-byte buffer
+     * @param privateKey A private key to encrypt this message with (Web Push: the local private key)
+     * @param keyid      An identifier for the local key. Only applies to AESGCM. For AES128GCM, the header contains the keyid.
+     * @param dh         An Elliptic curve Diffie-Hellman public privateKey on the P-256 curve (Web Push: the user's keys.p256dh)
+     * @param authSecret An authentication secret (Web Push: the user's keys.auth)
+     * @param version
+     * @return
+     * @throws GeneralSecurityException
+     */
+    public byte[] encrypt(byte[] plaintext, byte[] salt, byte[] privateKey, String keyid, ECPublicKey dh, byte[] authSecret, Encoding version) throws GeneralSecurityException {
+        log("encrypt", plaintext);
+
+        byte[][] keyAndNonce = deriveKeyAndNonce(salt, privateKey, keyid, dh, authSecret, version, ENCRYPT_MODE);
+        byte[] key = keyAndNonce[0];
+        byte[] nonce = keyAndNonce[1];
+
+        // Note: Cipher adds the tag to the end of the ciphertext
+        Cipher cipher = Cipher.getInstance("AES/GCM/NoPadding", "BC");
+        GCMParameterSpec params = new GCMParameterSpec(TAG_SIZE * 8, nonce);
+        cipher.init(ENCRYPT_MODE, new SecretKeySpec(key, "AES"), params);
+
+        // For AES128GCM suffix {0x02}, for AESGCM prefix {0x00, 0x00}.
+        if (version == Encoding.AES128GCM) {
+            byte[] header = buildHeader(salt, keyid);
+            log("header", header);
+
+            byte[] padding = new byte[] { 2 };
+            log("padding", padding);
+
+            byte[][] encrypted = {cipher.update(plaintext), cipher.update(padding), cipher.doFinal()};
+            log("encrypted", concat(encrypted));
+
+            return log("ciphertext", concat(header, concat(encrypted)));
+        } else {
+            return concat(cipher.update(new byte[2]), cipher.doFinal(plaintext));
+        }
+    }
+
+    /**
+     * Decrypt the payload.
+     *
+     * @param payload Header and body (ciphertext)
+     * @param salt    May be null when version is AES128GCM; the salt is extracted from the header.
+     * @param version AES128GCM or AESGCM.
+     * @return
+     */
+    public byte[] decrypt(byte[] payload, byte[] salt, byte[] key, String keyid, Encoding version) throws InvalidKeyException, NoSuchAlgorithmException, IllegalBlockSizeException, InvalidAlgorithmParameterException, BadPaddingException, NoSuchProviderException, NoSuchPaddingException {
+        byte[] body;
+
+        // Parse and strip the header
+        if (version == Encoding.AES128GCM) {
+            byte[][] header = parseHeader(payload);
+
+            salt = header[0];
+            keyid = new String(header[2]);
+            body = header[3];
+        } else {
+            body = payload;
+        }
+
+        // Derive key and nonce.
+        byte[][] keyAndNonce = deriveKeyAndNonce(salt, key, keyid, null, null, version, DECRYPT_MODE);
+
+        return decryptRecord(body, keyAndNonce[0], keyAndNonce[1], version);
+    }
+
+    public byte[][] parseHeader(byte[] payload) {
+        byte[] salt = Arrays.copyOfRange(payload, 0, KEY_LENGTH);
+        byte[] recordSize = Arrays.copyOfRange(payload, KEY_LENGTH, 20);
+        int keyIdLength = Arrays.copyOfRange(payload, 20, 21)[0];
+        byte[] keyId = Arrays.copyOfRange(payload, 21, 21 + keyIdLength);
+        byte[] body = Arrays.copyOfRange(payload, 21 + keyIdLength, payload.length);
+
+        return new byte[][] {
+                salt,
+                recordSize,
+                keyId,
+                body
+        };
+    }
+
+    public byte[] decryptRecord(byte[] ciphertext, byte[] key, byte[] nonce, Encoding version) throws NoSuchPaddingException, NoSuchAlgorithmException, NoSuchProviderException, InvalidAlgorithmParameterException, InvalidKeyException, BadPaddingException, IllegalBlockSizeException {
+        Cipher cipher = Cipher.getInstance("AES/GCM/NoPadding", "BC");
+        GCMParameterSpec params = new GCMParameterSpec(TAG_SIZE * 8, nonce);
+        cipher.init(DECRYPT_MODE, new SecretKeySpec(key, "AES"), params);
+
+        byte[] plaintext = cipher.doFinal(ciphertext);
+
+        if (version == Encoding.AES128GCM) {
+            // Remove one byte of padding at the end
+            return Arrays.copyOfRange(plaintext, 0, plaintext.length - 1);
+        } else {
+            // Remove two bytes of padding at the start
+            return Arrays.copyOfRange(plaintext, 2, plaintext.length);
+        }
+    }
+
+    /**
+     * Compute the Encryption Content Coding Header.
+     *
+     * See https://tools.ietf.org/html/draft-ietf-httpbis-encryption-encoding-09#section-2.1.
+     *
+     * @param salt  Array of 16 bytes
+     * @param keyid
+     * @return
+     */
+    private byte[] buildHeader(byte[] salt, String keyid) {
+        byte[] keyIdBytes;
+
+        if (keyid == null) {
+            keyIdBytes = new byte[0];
+        } else {
+            keyIdBytes = encode(getPublicKey(keyid));
+        }
+
+        if (keyIdBytes.length > 255) {
+            throw new IllegalArgumentException("They keyid is too large.");
+        }
+
+        byte[] rs = toByteArray(4096, 4);
+        byte[] idlen = new byte[] { (byte) keyIdBytes.length };
+
+        return concat(salt, rs, idlen, keyIdBytes);
     }
 
     /**
@@ -46,27 +198,35 @@ public class HttpEce {
     }
 
     /**
-     * Convenience method for computing the HMAC Key Derivation Function. The
-     * real work is offloaded to BouncyCastle.
+     * Convenience method for computing the HMAC Key Derivation Function. The real work is offloaded to BouncyCastle.
      */
-    protected static byte[] hkdfExpand(byte[] ikm, byte[] salt, byte[] info, int length) throws InvalidKeyException, NoSuchAlgorithmException {
+    protected static byte[] hkdfExpand(byte[] ikm, byte[] salt, byte[] info, int length) {
+        log("salt", salt);
+        log("ikm", ikm);
+        log("info", info);
+
         HKDFBytesGenerator hkdf = new HKDFBytesGenerator(new SHA256Digest());
         hkdf.init(new HKDFParameters(ikm, salt, info));
 
         byte[] okm = new byte[length];
         hkdf.generateBytes(okm, 0, length);
 
+        log("expand", okm);
+
         return okm;
     }
 
-    public byte[][] deriveKey(byte[] salt, byte[] key, String keyId, PublicKey dh, byte[] authSecret, int padSize) throws NoSuchPaddingException, NoSuchAlgorithmException, InvalidKeyException, InvalidAlgorithmParameterException, BadPaddingException, IllegalBlockSizeException, NoSuchProviderException, IOException {
+    public byte[][] extractSecretAndContext(byte[] key, String keyId, ECPublicKey dh, byte[] authSecret) throws InvalidKeyException, NoSuchAlgorithmException {
         byte[] secret = null;
         byte[] context = null;
 
         if (key != null) {
             secret = key;
+            if (secret.length != KEY_LENGTH) {
+                throw new IllegalStateException("An explicit key must be " + KEY_LENGTH + " bytes.");
+            }
         } else if (dh != null) {
-            byte[][] bytes = deriveDH(keyId, dh);
+            byte[][] bytes = extractDH(keyId, dh);
             secret = bytes[0];
             context = bytes[1];
         } else if (keyId != null) {
@@ -74,45 +234,12 @@ public class HttpEce {
         }
 
         if (secret == null) {
-            throw new IllegalStateException("Unable to determine the secret");
+            throw new IllegalStateException("Unable to determine key.");
         }
-
-        byte[] keyinfo;
-        byte[] nonceinfo;
 
         if (authSecret != null) {
-            secret = hkdfExpand(secret, authSecret, buildInfo("auth", new byte[0]), 32);
+            secret = hkdfExpand(secret, authSecret, buildInfo("auth", new byte[0]), SHA_256_LENGTH);
         }
-
-        keyinfo = buildInfo("aesgcm", context);
-        nonceinfo = buildInfo("nonce", context);
-
-        byte[] hkdf_key = hkdfExpand(secret, salt, keyinfo, 16);
-        byte[] hkdf_nonce = hkdfExpand(secret, salt, nonceinfo, 12);
-
-        return new byte[][]{
-                hkdf_key,
-                hkdf_nonce
-        };
-    }
-
-    /**
-     * Compute the shared secret using the server's key pair (indicated by
-     * keyId) and the client's public key. Also compute context.
-     *
-     * @param keyId
-     * @param publicKey
-     * @return
-     */
-    private byte[][] deriveDH(String keyId, PublicKey publicKey) throws NoSuchProviderException, NoSuchAlgorithmException, InvalidKeyException, IOException {
-        PublicKey senderPubKey = keys.get(keyId).getPublic();
-
-        KeyAgreement keyAgreement = KeyAgreement.getInstance("ECDH");
-        keyAgreement.init(keys.get(keyId).getPrivate());
-        keyAgreement.doPhase(publicKey, true);
-
-        byte[] secret = keyAgreement.generateSecret();
-        byte[] context = concat(labels.get(keyId).getBytes(UTF_8), new byte[1], lengthPrefix(publicKey), lengthPrefix(senderPubKey));
 
         return new byte[][]{
                 secret,
@@ -120,63 +247,199 @@ public class HttpEce {
         };
     }
 
-    private byte[] lengthPrefix(Key key) throws IOException {
-        byte[] bytes = Utils.savePublicKey((ECPublicKey) key);
+    public byte[][] deriveKeyAndNonce(byte[] salt, byte[] key, String keyId, ECPublicKey dh, byte[] authSecret, Encoding version, int mode) throws NoSuchAlgorithmException, InvalidKeyException {
+        byte[] secret;
+        byte[] keyInfo;
+        byte[] nonceInfo;
+
+        if (version == Encoding.AESGCM) {
+            byte[][] secretAndContext = extractSecretAndContext(key, keyId, dh, authSecret);
+            secret = secretAndContext[0];
+
+            keyInfo = buildInfo("aesgcm", secretAndContext[1]);
+            nonceInfo = buildInfo("nonce", secretAndContext[1]);
+        } else if (version == Encoding.AES128GCM) {
+            keyInfo = "Content-Encoding: aes128gcm\0".getBytes();
+            nonceInfo = "Content-Encoding: nonce\0".getBytes();
+
+            secret = extractSecret(key, keyId, dh, authSecret, mode);
+        } else {
+            throw new IllegalStateException("Unknown version: " + version);
+        }
+
+        byte[] hkdf_key = hkdfExpand(secret, salt, keyInfo, 16);
+        byte[] hkdf_nonce = hkdfExpand(secret, salt, nonceInfo, 12);
+
+        log("key", hkdf_key);
+        log("nonce", hkdf_nonce);
+
+        return new byte[][]{
+                hkdf_key,
+                hkdf_nonce
+        };
+    }
+
+    private byte[] extractSecret(byte[] key, String keyId, ECPublicKey dh, byte[] authSecret, int mode) throws InvalidKeyException, NoSuchAlgorithmException {
+        if (key != null) {
+            if (key.length != KEY_LENGTH) {
+                throw new IllegalArgumentException("An explicit key must be " + KEY_LENGTH + " bytes.");
+            }
+            return key;
+        }
+
+        if (dh == null) {
+            KeyPair keyPair = keys.get(keyId);
+
+            if (keyPair == null) {
+                throw new IllegalArgumentException("No saved key for keyid '" + keyId + "'.");
+            }
+
+            return encode((ECPublicKey) keyPair.getPublic());
+        }
+
+        return webpushSecret(keyId, dh, authSecret, mode);
+    }
+
+    /**
+     * Combine Shared and Authentication Secrets
+     *
+     * See https://tools.ietf.org/html/draft-ietf-webpush-encryption-09#section-3.3.
+     *
+     * @param keyId
+     * @param dh
+     * @param authSecret
+     * @param mode
+     * @return
+     * @throws NoSuchAlgorithmException
+     * @throws InvalidKeyException
+     */
+    public byte[] webpushSecret(String keyId, ECPublicKey dh, byte[] authSecret, int mode) throws NoSuchAlgorithmException, InvalidKeyException {
+        ECPublicKey senderPubKey;
+        ECPublicKey remotePubKey;
+        ECPublicKey receiverPubKey;
+
+        if (mode == ENCRYPT_MODE) {
+            senderPubKey = getPublicKey(keyId);
+            remotePubKey = dh;
+            receiverPubKey = dh;
+        } else if (mode == DECRYPT_MODE) {
+            remotePubKey = getPublicKey(keyId);
+            senderPubKey = remotePubKey;
+            receiverPubKey = dh;
+        } else {
+            throw new IllegalArgumentException("Unsupported mode: " + mode);
+        }
+
+        log("remote pubkey", encode(remotePubKey));
+        log("sender pubkey", encode(senderPubKey));
+        log("receiver pubkey", encode(receiverPubKey));
+
+        KeyAgreement keyAgreement = KeyAgreement.getInstance("ECDH");
+        keyAgreement.init(getPrivateKey(keyId));
+        keyAgreement.doPhase(remotePubKey, true);
+        byte[] secret = keyAgreement.generateSecret();
+
+        byte[] ikm = secret;
+        byte[] salt = authSecret;
+        byte[] info = concat(WEB_PUSH_INFO.getBytes(), encode(receiverPubKey), encode(senderPubKey));
+
+        return hkdfExpand(ikm, salt, info, SHA_256_LENGTH);
+    }
+
+    /**
+     * Compute the shared secret (using the server's key pair and the client's public key) and the context.
+     *
+     * @param keyid
+     * @param publicKey
+     * @return
+     */
+    private  byte[][] extractDH(String keyid, ECPublicKey publicKey) throws NoSuchAlgorithmException, InvalidKeyException {
+        ECPublicKey senderPubKey = getPublicKey(keyid);
+
+        KeyAgreement keyAgreement = KeyAgreement.getInstance("ECDH");
+        keyAgreement.init(getPrivateKey(keyid));
+        keyAgreement.doPhase(publicKey, true);
+
+        byte[] secret = keyAgreement.generateSecret();
+        byte[] context = concat(labels.get(keyid).getBytes(UTF_8), new byte[1], lengthPrefix(publicKey), lengthPrefix(senderPubKey));
+
+        return new byte[][]{
+                secret,
+                context
+        };
+    }
+
+    /**
+     * Get the public key for the given keyid.
+     *
+     * @param keyid
+     * @return
+     */
+    private ECPublicKey getPublicKey(String keyid) {
+        return (ECPublicKey) keys.get(keyid).getPublic();
+    }
+
+    /**
+     * Get the private key for the given keyid.
+     *
+     * @param keyid
+     * @return
+     */
+    private ECPrivateKey getPrivateKey(String keyid) {
+        return (ECPrivateKey) keys.get(keyid).getPrivate();
+    }
+
+
+    /**
+     * Encode the public key as a byte array and prepend its length in two bytes.
+     *
+     * @param publicKey
+     * @return
+     */
+    private static byte[] lengthPrefix(ECPublicKey publicKey) {
+        byte[] bytes = encode(publicKey);
 
         return concat(intToBytes(bytes.length), bytes);
     }
 
     /**
-     * Cast an integer to a two-byte array
+     * Convert an integer number to a two-byte binary number.
+     *
+     * This implementation:
+     *   1. masks all but the lowest eight bits
+     *   2. discards the lowest eight bits by moving all bits 8 places to the right.
+     *
+     * @param number
+     * @return
      */
-    private byte[] intToBytes(int x) throws IOException {
-        byte[] bytes = new byte[2];
+    private static byte[] intToBytes(int number) {
+        if (number < 0) {
+            throw new IllegalArgumentException("Cannot convert a negative number, " + number + " given.");
+        }
 
-        bytes[1] = (byte) (x & 0xff);
-        bytes[0] = (byte) (x >> 8);
+        if (number >= TWO_BYTE_MAX) {
+            throw new IllegalArgumentException("Cannot convert an integer larger than " + (TWO_BYTE_MAX - 1) + " to two bytes.");
+        }
+
+        byte[] bytes = new byte[2];
+        bytes[1] = (byte) (number & 0xff);
+        bytes[0] = (byte) (number >> 8);
 
         return bytes;
     }
 
     /**
-     * Utility to concat byte arrays
+     * Print the length and unpadded url-safe base64 encoding of the byte array.
+     *
+     * @param info
+     * @param array
+     * @return
      */
-    private byte[] concat(byte[]... arrays) {
-        int lastPos = 0;
-
-        byte[] combined = new byte[combinedLength(arrays)];
-
-        for (byte[] array : arrays) {
-            System.arraycopy(array, 0, combined, lastPos, array.length);
-
-            lastPos += array.length;
+    private static byte[] log(String info, byte[] array) {
+        if ("1".equals(System.getenv("ECE_KEYLOG"))) {
+            System.out.println(info + " [" + array.length + "]: " + Base64Encoder.encodeUrlWithoutPadding(array));
         }
 
-        return combined;
-    }
-
-    /**
-     * Compute combined array length
-     */
-    private int combinedLength(byte[]... arrays) {
-        int combinedLength = 0;
-
-        for (byte[] array : arrays) {
-            combinedLength += array.length;
-        }
-
-        return combinedLength;
-    }
-
-    public byte[] encrypt(byte[] buffer, byte[] salt, byte[] key, String keyid, PublicKey dh, byte[] authSecret, int padSize) throws NoSuchPaddingException, InvalidAlgorithmParameterException, NoSuchAlgorithmException, IllegalBlockSizeException, BadPaddingException, InvalidKeyException, NoSuchProviderException, IOException {
-        byte[][] derivedKey = deriveKey(salt, key, keyid, dh, authSecret, padSize);
-        byte[] key_ = derivedKey[0];
-        byte[] nonce_ = derivedKey[1];
-
-        Cipher cipher = Cipher.getInstance("AES/GCM/NoPadding", "BC");
-        cipher.init(Cipher.ENCRYPT_MODE, new SecretKeySpec(key_, "AES"), new GCMParameterSpec(16 * 8, nonce_));
-        cipher.update(new byte[padSize]);
-
-        return cipher.doFinal(buffer);
+        return array;
     }
 }

--- a/src/main/java/nl/martijndwars/webpush/Notification.java
+++ b/src/main/java/nl/martijndwars/webpush/Notification.java
@@ -1,5 +1,7 @@
 package nl.martijndwars.webpush;
 
+import org.bouncycastle.jce.interfaces.ECPublicKey;
+
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.security.NoSuchAlgorithmException;
@@ -18,7 +20,7 @@ public class Notification {
     /**
      * The client's public key
      */
-    private final PublicKey userPublicKey;
+    private final ECPublicKey userPublicKey;
 
     /**
      * The client's auth
@@ -35,12 +37,17 @@ public class Notification {
      */
     private final int ttl;
 
-    public Notification(String endpoint, PublicKey userPublicKey, byte[] userAuth, byte[] payload, int ttl) {
+
+    public Notification(String endpoint, ECPublicKey userPublicKey, byte[] userAuth, byte[] payload, int ttl) {
         this.endpoint = endpoint;
         this.userPublicKey = userPublicKey;
         this.userAuth = userAuth;
         this.payload = payload;
         this.ttl = ttl;
+    }
+
+    public Notification(String endpoint, PublicKey userPublicKey, byte[] userAuth, byte[] payload, int ttl) {
+        this(endpoint, (ECPublicKey) userPublicKey, userAuth, payload, ttl);
     }
 
     public Notification(String endpoint, PublicKey userPublicKey, byte[] userAuth, byte[] payload) {
@@ -63,7 +70,7 @@ public class Notification {
         return endpoint;
     }
 
-    public PublicKey getUserPublicKey() {
+    public ECPublicKey getUserPublicKey() {
         return userPublicKey;
     }
 
@@ -90,10 +97,6 @@ public class Notification {
 
     public int getTTL() {
         return ttl;
-    }
-
-    public int getPadSize() {
-        return 2;
     }
 
     public String getOrigin() throws MalformedURLException {

--- a/src/main/java/nl/martijndwars/webpush/cli/handlers/GenerateKeyHandler.java
+++ b/src/main/java/nl/martijndwars/webpush/cli/handlers/GenerateKeyHandler.java
@@ -31,18 +31,21 @@ public class GenerateKeyHandler implements HandlerInterface {
     public void run() throws InvalidAlgorithmParameterException, NoSuchAlgorithmException, NoSuchProviderException, IOException {
         KeyPair keyPair = generateKeyPair();
 
-        byte[] publicKey = Utils.savePublicKey((ECPublicKey) keyPair.getPublic());
-        byte[] privateKey = Utils.savePrivateKey((ECPrivateKey) keyPair.getPrivate());
+        ECPublicKey publicKey = (ECPublicKey) keyPair.getPublic();
+        ECPrivateKey privateKey = (ECPrivateKey) keyPair.getPrivate();
+
+        byte[] encodedPublicKey = Utils.encode(publicKey);
+        byte[] encodedPrivateKey = Utils.encode(privateKey);
 
         if (generateKeyCommand.hasPublicKeyFile()) {
             writeKey(keyPair.getPublic(), new File(generateKeyCommand.getPublicKeyFile()));
         }
 
         System.out.println("PublicKey:");
-        System.out.println(Base64Encoder.encodeUrl(publicKey));
+        System.out.println(Base64Encoder.encodeUrl(encodedPublicKey));
 
         System.out.println("PrivateKey:");
-        System.out.println(Base64Encoder.encodeUrl(privateKey));
+        System.out.println(Base64Encoder.encodeUrl(encodedPrivateKey));
     }
 
     /**

--- a/src/test/java/nl/martijndwars/webpush/HttpEceTest.java
+++ b/src/test/java/nl/martijndwars/webpush/HttpEceTest.java
@@ -1,0 +1,103 @@
+package nl.martijndwars.webpush;
+
+import org.bouncycastle.jce.interfaces.ECPrivateKey;
+import org.bouncycastle.jce.provider.BouncyCastleProvider;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+
+import java.security.*;
+import java.util.HashMap;
+
+import static nl.martijndwars.webpush.Base64Encoder.decode;
+import static nl.martijndwars.webpush.Encoding.AES128GCM;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+
+class HttpEceTest {
+    @BeforeAll
+    public static void addSecurityProvider() {
+        Security.addProvider(new BouncyCastleProvider());
+    }
+
+    @Test
+    public void testZeroSaltAndKey() throws GeneralSecurityException {
+        HttpEce httpEce = new HttpEce();
+        String plaintext = "Hello";
+        byte[] salt = new byte[16];
+        byte[] key = new byte[16];
+        byte[] actual = httpEce.encrypt(plaintext.getBytes(), salt, key, null, null, null, AES128GCM);
+        byte[] expected = decode("AAAAAAAAAAAAAAAAAAAAAAAAEAAAMpsi6NfZUkOdJI96XyX0tavLqyIdiw");
+
+        assertArrayEquals(expected, actual);
+    }
+
+    /**
+     * See https://tools.ietf.org/html/draft-ietf-httpbis-encryption-encoding-09#section-3.1
+     *
+     * - Record size is 4096.
+     * - Input keying material is identified by an empty string.
+     *
+     * @throws GeneralSecurityException
+     */
+    @Test
+    public void testSampleEncryption() throws GeneralSecurityException {
+        HttpEce httpEce = new HttpEce();
+
+        byte[] plaintext = "I am the walrus".getBytes();
+        byte[] salt = decode("I1BsxtFttlv3u_Oo94xnmw");
+        byte[] key = decode("yqdlZ-tYemfogSmv7Ws5PQ");
+        byte[] actual = httpEce.encrypt(plaintext, salt, key, null, null, null, AES128GCM);
+        byte[] expected = decode("I1BsxtFttlv3u_Oo94xnmwAAEAAA-NAVub2qFgBEuQKRapoZu-IxkIva3MEB1PD-ly8Thjg");
+
+        assertArrayEquals(expected, actual);
+    }
+
+    @Test
+    public void testSampleEncryptDecrypt() throws GeneralSecurityException {
+        String encodedKey = "yqdlZ-tYemfogSmv7Ws5PQ";
+        String encodedSalt = "I1BsxtFttlv3u_Oo94xnmw";
+
+        // Prepare the key map, which maps a keyid to a keypair.
+        PrivateKey privateKey = Utils.loadPrivateKey(encodedKey);
+        PublicKey publicKey = Utils.loadPublicKey((ECPrivateKey) privateKey);
+        KeyPair keyPair = new KeyPair(publicKey, privateKey);
+
+        HashMap<String, KeyPair> keys = new HashMap<>();
+        keys.put("", keyPair);
+
+        HashMap<String, String> labels = new HashMap<>();
+        labels.put("", "P-256");
+
+        // Run the encryption and decryption
+        HttpEce httpEce = new HttpEce(keys, labels);
+
+        byte[] plaintext = "I am the walrus".getBytes();
+        byte[] salt = decode(encodedSalt);
+        byte[] key = decode(encodedKey);
+        byte[] ciphertext = httpEce.encrypt(plaintext, salt, key, null, null, null, AES128GCM);
+        byte[] decrypted = httpEce.decrypt(ciphertext, null, key, null, AES128GCM);
+
+        assertArrayEquals(plaintext, decrypted);
+    }
+
+    /**
+     * See https://tools.ietf.org/html/draft-ietf-httpbis-encryption-encoding-09#section-3.2
+     *
+     * TODO: This test is disabled because the library does not deal with multiple records yet.
+     *
+     * @throws GeneralSecurityException
+     */
+    @Test
+    @Disabled
+    public void testEncryptionWithMultipleRecords() throws GeneralSecurityException {
+        HttpEce httpEce = new HttpEce();
+
+        byte[] plaintext = "I am the walrus".getBytes();
+        byte[] salt = decode("uNCkWiNYzKTnBN9ji3-qWA");
+        byte[] key = decode("BO3ZVPxUlnLORbVGMpbT1Q");
+        byte[] actual = httpEce.encrypt(plaintext, salt, key, null, null, null, AES128GCM);
+        byte[] expected = decode("uNCkWiNYzKTnBN9ji3-qWAAAABkCYTHOG8chz_gnvgOqdGYovxyjuqRyJFjEDyoF1Fvkj6hQPdPHI51OEUKEpgz3SsLWIqS_uA");
+
+        assertArrayEquals(expected, actual);
+    }
+}

--- a/src/test/java/nl/martijndwars/webpush/PushServiceTest.java
+++ b/src/test/java/nl/martijndwars/webpush/PushServiceTest.java
@@ -20,6 +20,90 @@ public class PushServiceTest {
     }
 
     @Test
+    public void testAes128Gcm() throws Exception {
+        String endpoint = "https://fcm.googleapis.com/fcm/send/cZgR4jdX_a0:APA91bGtFF7ymruzk4OQak-Ck0phn_78WG5eU7ODdolIUB3bXlUUyH08j655HBlHZcRFkCywJRnP_lnFoBQ5WIiiUwdqXyG9ZQA72zV97c_h4i2m17CQcN_2Ycc8HtwDleSJCcsMAu_T";
+
+        // Base64 string user public key/auth
+        String userPublicKey = "BJ7H-eGuEwYMn2u4Rbue3YUvXfugPgEERt1nMW8DyJgFfXmAHgo0mZi5LfzHW65xvI4gYlCvL8qq1OzUks3IYzA";
+        String userAuth = "05MiKXdBb159mUy6G84vaA";
+
+        // Base64 string server public/private key
+        String publicKey = "BG15nGlC3qDleDkI6VPDVT4Ar28t2v2zcHthuRMyoU4nD-t1XpU-PUw8Ve9FH0Zrb0saJDwzi6AJYJAL_CmwNcw";
+        String privateKey = "gNc81rawd_fKWXpFOhllPUD6BJLIkePus7lQ46jMvTs";
+
+        // Construct notification
+        Notification notification = new Notification(endpoint, userPublicKey, userAuth, getPayload());
+
+        // Construct push service
+        PushService pushService = new PushService();
+        pushService.setPublicKey(publicKey);
+        pushService.setPrivateKey(privateKey);
+        pushService.setSubject("mailto:admin@domain.com");
+
+        // Send notification!
+        HttpResponse httpResponse = pushService.send(notification, Encoding.AES128GCM);
+
+        System.out.println(httpResponse.getStatusLine().getStatusCode());
+        System.out.println(IOUtils.toString(httpResponse.getEntity().getContent(), StandardCharsets.UTF_8));
+    }
+
+    @Test
+    public void testAesGcm() throws Exception {
+        String endpoint = "https://fcm.googleapis.com/fcm/send/cZgR4jdX_a0:APA91bGtFF7ymruzk4OQak-Ck0phn_78WG5eU7ODdolIUB3bXlUUyH08j655HBlHZcRFkCywJRnP_lnFoBQ5WIiiUwdqXyG9ZQA72zV97c_h4i2m17CQcN_2Ycc8HtwDleSJCcsMAu_T";
+
+        // Base64 string user public key/auth
+        String userPublicKey = "BJ7H-eGuEwYMn2u4Rbue3YUvXfugPgEERt1nMW8DyJgFfXmAHgo0mZi5LfzHW65xvI4gYlCvL8qq1OzUks3IYzA";
+        String userAuth = "05MiKXdBb159mUy6G84vaA";
+
+        // Base64 string server public/private key
+        String publicKey = "BG15nGlC3qDleDkI6VPDVT4Ar28t2v2zcHthuRMyoU4nD-t1XpU-PUw8Ve9FH0Zrb0saJDwzi6AJYJAL_CmwNcw";
+        String privateKey = "gNc81rawd_fKWXpFOhllPUD6BJLIkePus7lQ46jMvTs";
+
+        // Construct notification
+        Notification notification = new Notification(endpoint, userPublicKey, userAuth, getPayload());
+
+        // Construct push service
+        PushService pushService = new PushService();
+        pushService.setPublicKey(publicKey);
+        pushService.setPrivateKey(privateKey);
+        pushService.setSubject("mailto:admin@domain.com");
+
+        // Send notification!
+        HttpResponse httpResponse = pushService.send(notification, Encoding.AESGCM);
+
+        System.out.println(httpResponse.getStatusLine().getStatusCode());
+        System.out.println(IOUtils.toString(httpResponse.getEntity().getContent(), StandardCharsets.UTF_8));
+    }
+
+    @Test
+    public void testNoEncodingSpecified() throws Exception {
+        String endpoint = "https://fcm.googleapis.com/fcm/send/cZgR4jdX_a0:APA91bGtFF7ymruzk4OQak-Ck0phn_78WG5eU7ODdolIUB3bXlUUyH08j655HBlHZcRFkCywJRnP_lnFoBQ5WIiiUwdqXyG9ZQA72zV97c_h4i2m17CQcN_2Ycc8HtwDleSJCcsMAu_T";
+
+        // Base64 string user public key/auth
+        String userPublicKey = "BJ7H-eGuEwYMn2u4Rbue3YUvXfugPgEERt1nMW8DyJgFfXmAHgo0mZi5LfzHW65xvI4gYlCvL8qq1OzUks3IYzA";
+        String userAuth = "05MiKXdBb159mUy6G84vaA";
+
+        // Base64 string server public/private key
+        String publicKey = "BG15nGlC3qDleDkI6VPDVT4Ar28t2v2zcHthuRMyoU4nD-t1XpU-PUw8Ve9FH0Zrb0saJDwzi6AJYJAL_CmwNcw";
+        String privateKey = "gNc81rawd_fKWXpFOhllPUD6BJLIkePus7lQ46jMvTs";
+
+        // Construct notification
+        Notification notification = new Notification(endpoint, userPublicKey, userAuth, getPayload());
+
+        // Construct push service
+        PushService pushService = new PushService();
+        pushService.setPublicKey(publicKey);
+        pushService.setPrivateKey(privateKey);
+        pushService.setSubject("mailto:admin@domain.com");
+
+        // Send notification!
+        HttpResponse httpResponse = pushService.send(notification);
+
+        System.out.println(httpResponse.getStatusLine().getStatusCode());
+        System.out.println(IOUtils.toString(httpResponse.getEntity().getContent(), StandardCharsets.UTF_8));
+    }
+
+    @Test
     public void testPushFirefoxVapid() throws Exception {
         String endpoint = "https://updates.push.services.mozilla.com/wpush/v1/gAAAAABX1ZgBNvDz6ZIAh6OqNh3hN4ZLEa57oS22mHI70mnvrDbIi-MnJu7FxFzvMV31L_AnIxP_p1Ot47KP8Xmit3XIQjZDjTahqBPmmntWX8JM6AtRxcAHxmXH6KqhyWwL1QEA0jBp";
 

--- a/src/test/java/nl/martijndwars/webpush/PushTest.java
+++ b/src/test/java/nl/martijndwars/webpush/PushTest.java
@@ -10,11 +10,33 @@ import org.junit.jupiter.api.Test;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.security.*;
+import java.security.spec.InvalidKeySpecException;
 import java.util.concurrent.ExecutionException;
 
 public class PushTest {
     @Test
-    public void companionPushTest() throws GeneralSecurityException, InterruptedException, JoseException, ExecutionException, IOException {
+    public void testAes128Gcm() throws Exception {
+        Security.addProvider(new BouncyCastleProvider());
+
+        String publicKey = "BG15nGlC3qDleDkI6VPDVT4Ar28t2v2zcHthuRMyoU4nD-t1XpU-PUw8Ve9FH0Zrb0saJDwzi6AJYJAL_CmwNcw";
+        String privateKey = "gNc81rawd_fKWXpFOhllPUD6BJLIkePus7lQ46jMvTs";
+
+        Subscription subscription = new Gson().fromJson("{\"endpoint\":\"https://fcm.googleapis.com/fcm/send/cZgR4jdX_a0:APA91bGtFF7ymruzk4OQak-Ck0phn_78WG5eU7ODdolIUB3bXlUUyH08j655HBlHZcRFkCywJRnP_lnFoBQ5WIiiUwdqXyG9ZQA72zV97c_h4i2m17CQcN_2Ycc8HtwDleSJCcsMAu_T\",\"expirationTime\":null,\"keys\":{\"p256dh\":\"BJ7H-eGuEwYMn2u4Rbue3YUvXfugPgEERt1nMW8DyJgFfXmAHgo0mZi5LfzHW65xvI4gYlCvL8qq1OzUks3IYzA\",\"auth\":\"05MiKXdBb159mUy6G84vaA\"}}", Subscription.class);
+        Notification notification = new Notification(subscription, "Hello");
+
+        PushService pushService = new PushService();
+        pushService.setPublicKey(publicKey);
+        pushService.setPrivateKey(privateKey);
+        pushService.setSubject("mailto:admin@domain.com");
+
+        HttpResponse httpResponse = pushService.send(notification, Encoding.AES128GCM);
+
+        System.out.println(httpResponse.getStatusLine().getStatusCode());
+        System.out.println(IOUtils.toString(httpResponse.getEntity().getContent(), StandardCharsets.UTF_8));
+    }
+
+    @Test
+    public void companionPushTest() throws Exception {
         Security.addProvider(new BouncyCastleProvider());
 
         String publicKey = "BLzPK96e2_tX5pE9HA9D6j_H1fkZi3yEgpG1HGifioFtM1wWSoJBcV7vWAsXzIVngaVAm5lmnD2TwvF46ouYx0M";
@@ -38,10 +60,8 @@ public class PushTest {
     public void testPush() throws Exception {
         Security.addProvider(new BouncyCastleProvider());
 
-        Gson gson = new Gson();
-
         // Deserialize subscription object
-        Subscription subscription = gson.fromJson(
+        Subscription subscription = new Gson().fromJson(
                 "{\"endpoint\":\"https://fcm.googleapis.com/fcm/send/efI2iY2iI7g:APA91bFJMK9cNaCh9dDyQ8X3kuXEzVYlHGEJ2BLKG57n7H_NCjTyjJ87wczJKkAV8wfqo5iZRFnTJf1LgaqZ5NsNhGX2PTQQM5pPaCS41ogYfSY9KpfKZJTY410sUQG6yEDGjSuXrtbP\",\"keys\":{\"p256dh\":\"BHj7LOv2ARShKqY_RXP5zoSSpvAevF-VTzJFm9dXfTtnFg5wHVqei_74UOF8vr8kzY-3hR-wgdhGQOw10AxkmBI=\",\"auth\":\"cJN5ZAvblDfOo_Y_ibFZSg==\"}}",
                 Subscription.class
         );
@@ -82,10 +102,8 @@ public class PushTest {
     public void testPush2() throws Exception {
         Security.addProvider(new BouncyCastleProvider());
 
-        Gson gson = new Gson();
-
         // Deserialize subscription object
-        Subscription subscription = gson.fromJson(
+        Subscription subscription = new Gson().fromJson(
                 "{\"endpoint\":\"https://fcm.googleapis.com/fcm/send/crTeErRUPTc:APA91bFVWbWwmV5pT-ChX-lQRdR-e_WFB9TKlTgbrA7Ipq8s87pwgxtrSfmAItENo_uL6MDhv5n_G-HCqUR2YmgBF07dprhbwAsVOkpvv07H0CmYrMC7oss27oeIT5pUKbejBWQ1gcik\",\"keys\":{\"p256dh\":\"BOpf2C_Lt26VMbY9JfLCSEKfe3-MZ89KF3rDpZqBdweckBxvaw753hOj0ox5isqoBki8UgPox7FsgTCZ3CwDa5s=\",\"auth\":\"YupUeBKECwzdSwHNre11HA==\"}}",
                 Subscription.class
         );


### PR DESCRIPTION
* Updates the HttpEce implementation (HTTP Encrypted Content Encoding) to support both the 2nd and 9th version of the draft.
* Updates the PushService implementation to support the old AESGCM version and the new AES128GCM version. The default is to use AESGCM.