### PR TITLE
Fix GCM without VAPID (fixes #73)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 5.0.1
+
+* Bugfix: Only verify the VAPID key pair if the keys are actually present (fixes #73).
+* Improvement: Add test configurations for GCM-only to the selenium test suite.
+
 # 5.0.0
 
 * Use aes128gcm as the default encoding (#75).

--- a/src/main/java/nl/martijndwars/webpush/PushService.java
+++ b/src/main/java/nl/martijndwars/webpush/PushService.java
@@ -171,7 +171,11 @@ public class PushService {
      * @throws JoseException
      */
     public HttpPost preparePost(Notification notification, Encoding encoding) throws GeneralSecurityException, IOException, JoseException {
-        assert (Utils.verifyKeyPair(privateKey, publicKey));
+        if (privateKey != null && publicKey != null) {
+            if (!Utils.verifyKeyPair(privateKey, publicKey)) {
+                throw new IllegalStateException("Public key and private key do not match.");
+            }
+        }
 
         Encrypted encrypted = encrypt(
                 notification.getPayload(),

--- a/src/test/java/nl/martijndwars/webpush/selenium/Configuration.java
+++ b/src/test/java/nl/martijndwars/webpush/selenium/Configuration.java
@@ -4,15 +4,17 @@ public class Configuration {
     protected final String browser;
     protected final String version;
     protected final String publicKey;
+    protected final String gcmSenderId;
 
-    Configuration(String browser, String version, String publicKey) {
+    Configuration(String browser, String version, String publicKey, String gcmSenderId) {
         this.browser = browser;
         this.version = version;
         this.publicKey = publicKey;
+        this.gcmSenderId = gcmSenderId;
     }
 
     public boolean isVapid() {
-        return !publicKey.isEmpty();
+        return publicKey != null && !publicKey.isEmpty();
     }
 
     @Override

--- a/src/test/java/nl/martijndwars/webpush/selenium/SeleniumTests.java
+++ b/src/test/java/nl/martijndwars/webpush/selenium/SeleniumTests.java
@@ -1,14 +1,12 @@
 package nl.martijndwars.webpush.selenium;
 
 import nl.martijndwars.webpush.Base64Encoder;
-import nl.martijndwars.webpush.PushService;
 import org.bouncycastle.jce.provider.BouncyCastleProvider;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.DynamicTest;
 import org.junit.jupiter.api.TestFactory;
 
 import java.io.IOException;
-import java.security.GeneralSecurityException;
 import java.security.Security;
 import java.util.stream.Stream;
 
@@ -18,18 +16,14 @@ import static org.junit.jupiter.api.DynamicTest.dynamicTest;
  * SeleniumTest performs integration testing.
  */
 public class SeleniumTests {
-    protected static String PUBLIC_KEY = "BNFDO1MUnNpx0SuQyQcAAWYETa2+W8z/uc5sxByf/UZLHwAhFLwEDxS5iB654KHiryq0AxDhFXS7DVqXDKjjN+8=";
-    protected static String PRIVATE_KEY = "AM0aAyoIryzARADnIsSCwg1p1aWFAL3Idc8dNXpf74MH";
+    protected static final String GCM_SENDER_ID = "759071690750";
+    protected static final String PUBLIC_KEY = "BNFDO1MUnNpx0SuQyQcAAWYETa2+W8z/uc5sxByf/UZLHwAhFLwEDxS5iB654KHiryq0AxDhFXS7DVqXDKjjN+8=";
 
     protected static TestingService testingService = new TestingService("http://localhost:8090/api/");
     protected static int testSuiteId;
 
-    protected PushService pushService;
-
-    public SeleniumTests() throws GeneralSecurityException {
+    public SeleniumTests() {
         Security.addProvider(new BouncyCastleProvider());
-
-        pushService = new PushService(PUBLIC_KEY, PRIVATE_KEY, "http://localhost:8090");
     }
 
     /**
@@ -52,7 +46,7 @@ public class SeleniumTests {
         testSuiteId = testingService.startTestSuite();
 
         return getConfigurations().map(configuration -> {
-            BrowserTest browserTest = new BrowserTest(pushService, testingService, configuration, testSuiteId);
+            BrowserTest browserTest = new BrowserTest(testingService, configuration, testSuiteId);
 
             return dynamicTest(browserTest.getDisplayName(), browserTest);
         });
@@ -69,12 +63,19 @@ public class SeleniumTests {
         );
 
         return Stream.of(
-                new Configuration("chrome", "stable", PUBLIC_KEY_NO_PADDING),
-                new Configuration("chrome", "beta", PUBLIC_KEY_NO_PADDING),
-                new Configuration("chrome", "unstable", PUBLIC_KEY_NO_PADDING),
+                new Configuration("chrome", "stable", null, GCM_SENDER_ID),
+                new Configuration("chrome", "beta", null, GCM_SENDER_ID),
+                new Configuration("chrome", "unstable", null, GCM_SENDER_ID),
 
-                new Configuration("firefox", "stable", PUBLIC_KEY_NO_PADDING),
-                new Configuration("firefox", "beta", PUBLIC_KEY_NO_PADDING)
+                new Configuration("firefox", "stable", null, GCM_SENDER_ID),
+                new Configuration("firefox", "beta", null, GCM_SENDER_ID),
+
+                new Configuration("chrome", "stable", PUBLIC_KEY_NO_PADDING, null),
+                new Configuration("chrome", "beta", PUBLIC_KEY_NO_PADDING, null),
+                new Configuration("chrome", "unstable", PUBLIC_KEY_NO_PADDING, null),
+
+                new Configuration("firefox", "stable", PUBLIC_KEY_NO_PADDING, null),
+                new Configuration("firefox", "beta", PUBLIC_KEY_NO_PADDING, null)
         );
     }
 }

--- a/src/test/java/nl/martijndwars/webpush/selenium/TestingService.java
+++ b/src/test/java/nl/martijndwars/webpush/selenium/TestingService.java
@@ -1,10 +1,10 @@
 package nl.martijndwars.webpush.selenium;
 
-import org.apache.commons.io.IOUtils;
 import com.google.gson.JsonArray;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonParser;
+import org.apache.commons.io.IOUtils;
 import org.apache.http.HttpEntity;
 import org.apache.http.client.fluent.Request;
 import org.apache.http.entity.ContentType;
@@ -12,6 +12,7 @@ import org.apache.http.entity.StringEntity;
 import org.apache.http.util.EntityUtils;
 
 import java.io.IOException;
+
 import static java.nio.charset.StandardCharsets.UTF_8;
 
 /**
@@ -55,7 +56,14 @@ public class TestingService {
         jsonObject.addProperty("testSuiteId", testSuiteId);
         jsonObject.addProperty("browserName", configuration.browser);
         jsonObject.addProperty("browserVersion", configuration.version);
-        jsonObject.addProperty("vapidPublicKey", configuration.publicKey);
+
+        if (configuration.gcmSenderId != null) {
+            jsonObject.addProperty("gcmSenderId", configuration.gcmSenderId);
+        }
+
+        if (configuration.publicKey != null) {
+            jsonObject.addProperty("vapidPublicKey", configuration.publicKey);
+        }
 
         HttpEntity entity = new StringEntity(jsonObject.toString(), ContentType.APPLICATION_JSON);
 


### PR DESCRIPTION
* Only verify the VAPID key pair if the keys are actually present (fixes #73).
* Add test configurations for GCM-only to the selenium test suite.