### PR TITLE
Apply gcm header to fcm endpoints

### DIFF
--- a/src/main/java/nl/martijndwars/webpush/Notification.java
+++ b/src/main/java/nl/martijndwars/webpush/Notification.java
@@ -95,6 +95,10 @@ public class Notification {
         return getEndpoint().indexOf("https://android.googleapis.com/gcm/send") == 0;
     }
 
+    public boolean isFcm() {
+        return getEndpoint().indexOf("https://fcm.googleapis.com/fcm/send") == 0;
+    }
+
     public int getTTL() {
         return ttl;
     }

--- a/src/main/java/nl/martijndwars/webpush/PushService.java
+++ b/src/main/java/nl/martijndwars/webpush/PushService.java
@@ -244,6 +244,8 @@ public class PushService {
             } else {
                 headers.put("Crypto-Key", "p256ecdsa=" + Base64Encoder.encodeUrl(pk));
             }
+        } else if (notification.isFcm() && gcmApiKey != null) {
+            headers.put("Authorization", "key=" + gcmApiKey);
         }
 
         for (Map.Entry<String, String> entry : headers.entrySet()) {


### PR DESCRIPTION
[Google announced that old gcm endpoints need to be redirected to fcm.](https://developers.google.com/cloud-messaging/android/android-migrate-fcm)

If the GCM auth key is supplied, apply it to both gcm and fcm endpoints.