### PR TITLE
Adding support for Urgency

### DIFF
--- a/src/main/java/nl/martijndwars/webpush/Notification.java
+++ b/src/main/java/nl/martijndwars/webpush/Notification.java
@@ -33,21 +33,30 @@ public class Notification {
     private final byte[] payload;
 
     /**
+     * Push Message Urgency
+     *
+     *  @see <a href="https://tools.ietf.org/html/rfc8030#section-5.3">Push Message Urgency</a>
+     *
+     */
+    private Urgency urgency;
+
+    /**
      * Time in seconds that the push message is retained by the push service
      */
     private final int ttl;
 
 
-    public Notification(String endpoint, ECPublicKey userPublicKey, byte[] userAuth, byte[] payload, int ttl) {
+    public Notification(String endpoint, ECPublicKey userPublicKey, byte[] userAuth, byte[] payload, int ttl, Urgency urgency) {
         this.endpoint = endpoint;
         this.userPublicKey = userPublicKey;
         this.userAuth = userAuth;
         this.payload = payload;
         this.ttl = ttl;
+        this.urgency = urgency;
     }
 
     public Notification(String endpoint, PublicKey userPublicKey, byte[] userAuth, byte[] payload, int ttl) {
-        this(endpoint, (ECPublicKey) userPublicKey, userAuth, payload, ttl);
+        this(endpoint, (ECPublicKey) userPublicKey, userAuth, payload, ttl, null);
     }
 
     public Notification(String endpoint, PublicKey userPublicKey, byte[] userAuth, byte[] payload) {
@@ -64,6 +73,11 @@ public class Notification {
 
     public Notification(Subscription subscription, String payload) throws NoSuchAlgorithmException, NoSuchProviderException, InvalidKeySpecException {
         this(subscription.endpoint, subscription.keys.p256dh, subscription.keys.auth, payload);
+    }
+
+    public Notification(Subscription subscription, String payload, Urgency urgency) throws NoSuchAlgorithmException, NoSuchProviderException, InvalidKeySpecException {
+        this(subscription.endpoint, subscription.keys.p256dh, subscription.keys.auth, payload);
+        this.urgency = urgency;
     }
 
     public String getEndpoint() {
@@ -86,6 +100,10 @@ public class Notification {
         return getPayload().length > 0;
     }
 
+    public boolean hasUrgency() {
+        return urgency != null;
+    }
+
     /**
      * Detect if the notification is for a GCM-based subscription
      *
@@ -101,6 +119,10 @@ public class Notification {
 
     public int getTTL() {
         return ttl;
+    }
+
+    public Urgency getUrgency() {
+        return urgency;
     }
 
     public String getOrigin() throws MalformedURLException {

--- a/src/main/java/nl/martijndwars/webpush/Notification.java
+++ b/src/main/java/nl/martijndwars/webpush/Notification.java
@@ -71,6 +71,11 @@ public class Notification {
         this(endpoint, Utils.loadPublicKey(userPublicKey), Base64Encoder.decode(userAuth), payload.getBytes(UTF_8));
     }
 
+	public Notification(String endpoint, String userPublicKey, String userAuth, String payload, Urgency urgency) throws NoSuchAlgorithmException, NoSuchProviderException, InvalidKeySpecException {
+		this(endpoint, Utils.loadPublicKey(userPublicKey), Base64Encoder.decode(userAuth), payload.getBytes(UTF_8));
+		this.urgency = urgency;
+	}
+
     public Notification(Subscription subscription, String payload) throws NoSuchAlgorithmException, NoSuchProviderException, InvalidKeySpecException {
         this(subscription.endpoint, subscription.keys.p256dh, subscription.keys.auth, payload);
     }

--- a/src/main/java/nl/martijndwars/webpush/PushService.java
+++ b/src/main/java/nl/martijndwars/webpush/PushService.java
@@ -191,7 +191,7 @@ public class PushService {
         httpPost.addHeader("TTL", String.valueOf(notification.getTTL()));
 
         if (notification.hasUrgency()) {
-            httpPost.addHeader("urgency", notification.getUrgency().getHeaderValue());
+            httpPost.addHeader("Urgency", notification.getUrgency().getHeaderValue());
         }
 
         Map<String, String> headers = new HashMap<>();

--- a/src/main/java/nl/martijndwars/webpush/PushService.java
+++ b/src/main/java/nl/martijndwars/webpush/PushService.java
@@ -190,6 +190,10 @@ public class PushService {
         HttpPost httpPost = new HttpPost(notification.getEndpoint());
         httpPost.addHeader("TTL", String.valueOf(notification.getTTL()));
 
+        if (notification.hasUrgency()) {
+            httpPost.addHeader("urgency", notification.getUrgency().getHeaderValue());
+        }
+
         Map<String, String> headers = new HashMap<>();
 
         if (notification.hasPayload()) {

--- a/src/main/java/nl/martijndwars/webpush/Urgency.java
+++ b/src/main/java/nl/martijndwars/webpush/Urgency.java
@@ -1,0 +1,24 @@
+package nl.martijndwars.webpush;
+
+
+/**
+ * Web Push Message Urgency header field values
+ *
+ *  @see <a href="https://tools.ietf.org/html/rfc8030#section-5.3">Push Message Urgency</a>
+ */
+public enum Urgency {
+	VERY_LOW("very-low"),
+	LOW("low"),
+	NORMAL("normal"),
+	HIGH("high");
+
+	private final String headerValue;
+
+	Urgency(String urgency) {
+		this.headerValue = urgency;
+	}
+
+	public String getHeaderValue() {
+		return headerValue;
+	}
+}


### PR DESCRIPTION
I spent a while trying to trouble shooting issues related to web push notifications not being delivered to Android devices and after going down a lot of dead ends, adding this urgency header to my FCM message has finally fixed my issue.

I noticed that someone requested this feature already but it hasn't been implemented yet: #29.

Hopefully you find this PR useful and can integrate it in to your project and get a new release pushed to out maven central. Let me know if you have any questions or concerns!