### PR TITLE
Adding support for push notification topics

### DIFF
--- a/src/main/java/nl/martijndwars/webpush/Notification.java
+++ b/src/main/java/nl/martijndwars/webpush/Notification.java
@@ -41,6 +41,14 @@ public class Notification {
     private Urgency urgency;
 
     /**
+     * Push Message Topic
+     *
+     *  @see <a href="https://tools.ietf.org/html/rfc8030#section-5.4">Replacing Push Messages</a>
+     *
+     */
+    private String topic;
+
+    /**
      * Time in seconds that the push message is retained by the push service
      */
     private final int ttl;
@@ -48,18 +56,18 @@ public class Notification {
     private static final int ONE_DAY_DURATION_IN_SECONDS = 86400;
     private static int DEFAULT_TTL = 28 * ONE_DAY_DURATION_IN_SECONDS;
 
-
-    public Notification(String endpoint, ECPublicKey userPublicKey, byte[] userAuth, byte[] payload, int ttl, Urgency urgency) {
+    public Notification(String endpoint, ECPublicKey userPublicKey, byte[] userAuth, byte[] payload, int ttl, Urgency urgency, String topic) {
         this.endpoint = endpoint;
         this.userPublicKey = userPublicKey;
         this.userAuth = userAuth;
         this.payload = payload;
         this.ttl = ttl;
         this.urgency = urgency;
+        this.topic = topic;
     }
 
     public Notification(String endpoint, PublicKey userPublicKey, byte[] userAuth, byte[] payload, int ttl) {
-        this(endpoint, (ECPublicKey) userPublicKey, userAuth, payload, ttl, null);
+        this(endpoint, (ECPublicKey) userPublicKey, userAuth, payload, ttl, null, null);
     }
 
     public Notification(String endpoint, String userPublicKey, String userAuth, byte[] payload, int ttl)  throws NoSuchAlgorithmException, NoSuchProviderException, InvalidKeySpecException {
@@ -116,6 +124,10 @@ public class Notification {
         return urgency != null;
     }
 
+    public boolean hasTopic() {
+        return topic != null;
+    }
+
     /**
      * Detect if the notification is for a GCM-based subscription
      *
@@ -137,6 +149,10 @@ public class Notification {
         return urgency;
     }
 
+    public String getTopic() {
+        return topic;
+    }
+
     public String getOrigin() throws MalformedURLException {
         URL url = new URL(getEndpoint());
 
@@ -153,12 +169,14 @@ public class Notification {
         private byte[] userAuth = null;
         private byte[] payload = null;
         private int ttl = DEFAULT_TTL;
+        private Urgency urgency = null;
+        private String topic = null;
 
         private NotificationBuilder() {
         }
 
         public Notification build() {
-            return new Notification(endpoint, userPublicKey, userAuth, payload, ttl);
+            return new Notification(endpoint, userPublicKey, userAuth, payload, ttl, urgency, topic);
         }
 
         public NotificationBuilder endpoint(String endpoint) {
@@ -191,8 +209,23 @@ public class Notification {
             return this;
         }
 
+        public NotificationBuilder payload(String payload) {
+            this.payload = payload.getBytes(UTF_8);
+            return this;
+        }
+
         public NotificationBuilder ttl(int ttl) {
             this.ttl = ttl;
+            return this;
+        }
+
+        public NotificationBuilder urgency(Urgency urgency) {
+            this.urgency = urgency;
+            return this;
+        }
+
+        public NotificationBuilder topic(String topic) {
+            this.topic = topic;
             return this;
         }
     }

--- a/src/main/java/nl/martijndwars/webpush/Notification.java
+++ b/src/main/java/nl/martijndwars/webpush/Notification.java
@@ -33,21 +33,30 @@ public class Notification {
     private final byte[] payload;
 
     /**
+     * Push Message Urgency
+     *
+     *  @see <a href="https://tools.ietf.org/html/rfc8030#section-5.3">Push Message Urgency</a>
+     *
+     */
+    private Urgency urgency;
+
+    /**
      * Time in seconds that the push message is retained by the push service
      */
     private final int ttl;
 
 
-    public Notification(String endpoint, ECPublicKey userPublicKey, byte[] userAuth, byte[] payload, int ttl) {
+    public Notification(String endpoint, ECPublicKey userPublicKey, byte[] userAuth, byte[] payload, int ttl, Urgency urgency) {
         this.endpoint = endpoint;
         this.userPublicKey = userPublicKey;
         this.userAuth = userAuth;
         this.payload = payload;
         this.ttl = ttl;
+        this.urgency = urgency;
     }
 
     public Notification(String endpoint, PublicKey userPublicKey, byte[] userAuth, byte[] payload, int ttl) {
-        this(endpoint, (ECPublicKey) userPublicKey, userAuth, payload, ttl);
+        this(endpoint, (ECPublicKey) userPublicKey, userAuth, payload, ttl, null);
     }
 
     public Notification(String endpoint, PublicKey userPublicKey, byte[] userAuth, byte[] payload) {
@@ -64,6 +73,11 @@ public class Notification {
 
     public Notification(Subscription subscription, String payload) throws NoSuchAlgorithmException, NoSuchProviderException, InvalidKeySpecException {
         this(subscription.endpoint, subscription.keys.p256dh, subscription.keys.auth, payload);
+    }
+
+    public Notification(Subscription subscription, String payload, Urgency urgency) throws NoSuchAlgorithmException, NoSuchProviderException, InvalidKeySpecException {
+        this(subscription.endpoint, subscription.keys.p256dh, subscription.keys.auth, payload);
+        this.urgency = urgency;
     }
 
     public String getEndpoint() {
@@ -86,6 +100,10 @@ public class Notification {
         return getPayload().length > 0;
     }
 
+    public boolean hasUrgency() {
+        return urgency != null;
+    }
+
     /**
      * Detect if the notification is for a GCM-based subscription
      *
@@ -101,6 +119,10 @@ public class Notification {
 
     public int getTTL() {
         return ttl;
+    }
+
+    public Urgency getUrgency() {
+        return urgency;
     }
 
     public String getOrigin() throws MalformedURLException {

--- a/src/main/java/nl/martijndwars/webpush/Notification.java
+++ b/src/main/java/nl/martijndwars/webpush/Notification.java
@@ -71,6 +71,11 @@ public class Notification {
         this(endpoint, Utils.loadPublicKey(userPublicKey), Base64Encoder.decode(userAuth), payload.getBytes(UTF_8));
     }
 
+	public Notification(String endpoint, String userPublicKey, String userAuth, String payload, Urgency urgency) throws NoSuchAlgorithmException, NoSuchProviderException, InvalidKeySpecException {
+		this(endpoint, Utils.loadPublicKey(userPublicKey), Base64Encoder.decode(userAuth), payload.getBytes(UTF_8));
+		this.urgency = urgency;
+	}
+
     public Notification(Subscription subscription, String payload) throws NoSuchAlgorithmException, NoSuchProviderException, InvalidKeySpecException {
         this(subscription.endpoint, subscription.keys.p256dh, subscription.keys.auth, payload);
     }

--- a/src/main/java/nl/martijndwars/webpush/PushService.java
+++ b/src/main/java/nl/martijndwars/webpush/PushService.java
@@ -191,7 +191,7 @@ public class PushService {
         httpPost.addHeader("TTL", String.valueOf(notification.getTTL()));
 
         if (notification.hasUrgency()) {
-            httpPost.addHeader("urgency", notification.getUrgency().getHeaderValue());
+            httpPost.addHeader("Urgency", notification.getUrgency().getHeaderValue());
         }
 
         Map<String, String> headers = new HashMap<>();

--- a/src/main/java/nl/martijndwars/webpush/PushService.java
+++ b/src/main/java/nl/martijndwars/webpush/PushService.java
@@ -203,6 +203,10 @@ public class PushService {
             httpPost.addHeader("Urgency", notification.getUrgency().getHeaderValue());
         }
 
+        if (notification.hasTopic()) {
+            httpPost.addHeader("Topic", notification.getTopic());
+        }
+
         Map<String, String> headers = new HashMap<>();
 
         if (notification.hasPayload()) {

--- a/src/main/java/nl/martijndwars/webpush/PushService.java
+++ b/src/main/java/nl/martijndwars/webpush/PushService.java
@@ -190,6 +190,10 @@ public class PushService {
         HttpPost httpPost = new HttpPost(notification.getEndpoint());
         httpPost.addHeader("TTL", String.valueOf(notification.getTTL()));
 
+        if (notification.hasUrgency()) {
+            httpPost.addHeader("urgency", notification.getUrgency().getHeaderValue());
+        }
+
         Map<String, String> headers = new HashMap<>();
 
         if (notification.hasPayload()) {

--- a/src/main/java/nl/martijndwars/webpush/Urgency.java
+++ b/src/main/java/nl/martijndwars/webpush/Urgency.java
@@ -1,0 +1,24 @@
+package nl.martijndwars.webpush;
+
+
+/**
+ * Web Push Message Urgency header field values
+ *
+ *  @see <a href="https://tools.ietf.org/html/rfc8030#section-5.3">Push Message Urgency</a>
+ */
+public enum Urgency {
+	VERY_LOW("very-low"),
+	LOW("low"),
+	NORMAL("normal"),
+	HIGH("high");
+
+	private final String headerValue;
+
+	Urgency(String urgency) {
+		this.headerValue = urgency;
+	}
+
+	public String getHeaderValue() {
+		return headerValue;
+	}
+}


### PR DESCRIPTION
See push notification specification for topics:

https://tools.ietf.org/html/rfc8030#section-5.4

This allows push notifications in the push notification service side to overwrite undelivered messages with updates instead of pushing out outdated messages when a push notification subscriber becomes available.