### PR TITLE
Update org.asynchttpclient:async-http-client to 2.12.4

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -27,7 +27,7 @@ dependencies {
     implementation group: 'org.apache.httpcomponents', name: 'httpasyncclient', version: '4.1.5'
 
     // For making async HTTP requests
-    implementation group: 'org.asynchttpclient', name: 'async-http-client', version: '2.12.3'
+    implementation group: 'org.asynchttpclient', name: 'async-http-client', version: '2.12.4'
 
     // For cryptographic operations
     shadow group: 'org.bouncycastle', name: 'bcprov-jdk15on', version: '1.70'


### PR DESCRIPTION
A CVE was reported against `org.asynchttpclient:async-http-client` 2.12.3

* Vulnerability: CVE-2024-53990
* Fixed Version: 2.12.4, 3.0.1
* Title: async-http-client: AsyncHttpClient (AHC) library's `CookieStore` replaces explicitly defined `Cookie`s 

See:
* https://avd.aquasec.com/nvd/cve-2024-53990
* https://github.com/AsyncHttpClient/async-http-client/security/advisories/GHSA-mfj5-cf8g-g2fv

This pull request is updating the library to version 2.12.4