### PR TITLE
Update org.bitbucket.b_c:jose4j to 0.9.4

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -33,7 +33,7 @@ dependencies {
     shadow group: 'org.bouncycastle', name: 'bcprov-jdk15on', version: '1.70'
 
     // For creating and signing JWT
-    implementation group: 'org.bitbucket.b_c', name: 'jose4j', version: '0.9.4'
+    implementation group: 'org.bitbucket.b_c', name: 'jose4j', version: '0.9.6'
 
     // For parsing JSON
     testImplementation group: 'com.google.code.gson', name: 'gson', version: '2.8.9'

--- a/build.gradle
+++ b/build.gradle
@@ -33,7 +33,7 @@ dependencies {
     shadow group: 'org.bouncycastle', name: 'bcprov-jdk15on', version: '1.70'
 
     // For creating and signing JWT
-    implementation group: 'org.bitbucket.b_c', name: 'jose4j', version: '0.7.9'
+    implementation group: 'org.bitbucket.b_c', name: 'jose4j', version: '0.9.4'
 
     // For parsing JSON
     testImplementation group: 'com.google.code.gson', name: 'gson', version: '2.8.9'


### PR DESCRIPTION
There are 2 vulnerabilities reported for `org.bitbucket.b_c:jose4j` 0.7.9

[CVE-2023-31582](https://github.com/advisories/GHSA-7g24-qg88-p43q):
- Severity: High
- Patched versions: 0.9.3

[CVE-2023-51775](https://github.com/advisories/GHSA-6qvw-249j-h44c):
- Severity: Moderate
- Patched versions: 0.9.4

This pull request updates `org.bitbucket.b_c:jose4j` to `0.9.4` to address those vulnerabilities.