### PR TITLE
chore: Set AES128GCM as default encoding

### DIFF
--- a/src/main/java/nl/martijndwars/webpush/PushService.java
+++ b/src/main/java/nl/martijndwars/webpush/PushService.java
@@ -65,7 +65,7 @@ public class PushService extends AbstractPushService<PushService> {
     }
 
     public HttpResponse send(Notification notification) throws GeneralSecurityException, IOException, JoseException, ExecutionException, InterruptedException {
-        return send(notification, Encoding.AESGCM);
+        return send(notification, Encoding.AES128GCM);
     }
 
     /**


### PR DESCRIPTION
## Summary

This PR changes the default encryption encoding used in the `PushService` class from `AESGCM` to `AES128GCM`.

## Rationale

While `AESGCM` is a newer encoding method, some modern browsers (e.g., Chrome, Edge) currently do **not properly trigger service workers** when receiving push notifications encoded with `aesgcm`. 

By contrast, `aes128gcm` is widely supported and works reliably across all major browsers. This change ensures more consistent and reliable push notification delivery.

## Changes

- Updated the `send(Notification)` method in `PushService` to use `Encoding.AES128GCM` by default.

## Reference

- [MDN Web Push documentation](https://developer.mozilla.org/en-US/docs/Web/API/Push_API)
- [Web Push encryption reference](https://tools.ietf.org/html/draft-ietf-webpush-encryption)


##Notes

- This is My First Contribution , Give any Opinion And Advice Freely.
